### PR TITLE
Add shipit to approval comment expressions

### DIFF
--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -66,7 +66,8 @@ def pull_request_approved_before_merging(pull_request: PullRequest) -> bool:
 def _is_approval_comment_body(body: str) -> bool:
     return (
         re.search(
-            "lgtm|looks good|look good|looks great|look great|\+1|👍", body.lower()
+            "lgtm|looks good|look good|looks great|look great|\+1|ship\s?it|👍|🚢",
+            body.lower(),
         )
         is not None
     )


### PR DESCRIPTION
So we keep the functionality from https://github.com/Asana/LGTM/pull/32 when we move over to python 


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1163436749112786)