### PR TITLE
Include the payload body in the signature

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -22,7 +22,12 @@ def handler(event: dict, context: dict) -> None:
     secret: str = GITHUB_HMAC_SECRET
 
     generated_signature = (
-        "sha1=" + hmac.new(bytes(secret, "utf-8"), digestmod=hashlib.sha1).hexdigest()
+        "sha1="
+        + hmac.new(
+            bytes(secret, "utf-8"),
+            msg=bytes(event["body"], "utf-8"),
+            digestmod=hashlib.sha1,
+        ).hexdigest()
     )
 
     if not hmac.compare_digest(generated_signature, signature):


### PR DESCRIPTION
The `compare_digest` was failing because we weren't including the payload body as part of the signature. I pushed this code, so if this PR syncs then we know it's working :)


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1170883468042253)