### PR TITLE
Remove special casing of no review body

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -246,14 +246,6 @@ def asana_comment_from_github_review(review: Review) -> str:
         for comment_text in comment_texts
     ]
 
-    if not review_body and inline_comments:
-        return _wrap_in_tag("body")(
-            _wrap_in_tag("strong")(
-                f"{user_display_name} left inline comments:\n"
-                + "\n\n".join(inline_comments)
-            )
-        )
-
     return _wrap_in_tag("body")(
         (
             (

--- a/test/asana/helpers/test_asana_comment_from_github_review.py
+++ b/test/asana/helpers/test_asana_comment_from_github_review.py
@@ -33,6 +33,26 @@ class TestAsanaCommentFromGitHubReview(MockDynamoDbTestCase):
             asana_review_comment, ["GITHUB_REVIEW_TEXT", "GITHUB_REVIEW_COMMENT_TEXT"]
         )
 
+    def test_handles_no_review_text(self):
+        github_review = build(
+            builder.review()
+            .author(builder.user("github_unknown_user_login"))
+            .state("APPROVED")
+            .body("")
+            .comment(builder.comment().body("GITHUB_REVIEW_COMMENT_TEXT"))
+        )
+        asana_review_comment = src.asana.helpers.asana_comment_from_github_review(
+            github_review
+        )
+        self.assertContainsStrings(
+            asana_review_comment,
+            [
+                "GitHub user 'github_unknown_user_login' approved",
+                "and left inline comments:",
+                "GITHUB_REVIEW_COMMENT_TEXT",
+            ],
+        )
+
     def test_includes_asana_review_comment_author(self):
         github_review = build(
             builder.review()

--- a/test/impl/mock_dynamodb_test_case.py
+++ b/test/impl/mock_dynamodb_test_case.py
@@ -47,7 +47,6 @@ class MockDynamoDbTestCase(BaseClass):
         client.create_table(
             AttributeDefinitions=[
                 {"AttributeName": "github/handle", "AttributeType": "S",},
-                {"AttributeName": "asana/domain-user-id", "AttributeType": "S",},
             ],
             TableName=USERS_TABLE,
             KeySchema=[{"AttributeName": "github/handle", "KeyType": "HASH",}],


### PR DESCRIPTION
We're already handling the case where the review body may be empty or the inline comments may be empty -- this was unnecessary and wrapped improperly to show all bold


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1173778496554947)