### PR TITLE
Add TTL to dynamodb locks table

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -187,6 +187,11 @@ resource "aws_dynamodb_table" "sgtm-lock" {
     name = "sort_key"
     type = "S"
   }
+
+  ttl {
+    attribute_name = "expiry_time"
+    enabled        = true
+  }
 }
 
 resource "aws_dynamodb_table" "sgtm-objects" {


### PR DESCRIPTION
See: https://github.com/mohankishore/python_dynamodb_lock/blob/1a2725a83534cd544f5faec75681c0ae8c835143/python_dynamodb_lock/python_dynamodb_lock.py#L752-L758 -- this table expects there to be a TTL, which helps us clean up locks that failed to get released properly


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1175721139201743)