### PR TITLE
Add UpdateItem to sgtm-lock table

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -24,7 +24,8 @@ resource "aws_iam_policy" "lambda-function-dynamodb-policy" {
     },
     {
       "Action": [
-        "dynamodb:DeleteItem"
+        "dynamodb:DeleteItem",
+        "dynamodb:UpdateItem"
       ],
       "Resource": [
         "${aws_dynamodb_table.sgtm-lock.arn}"


### PR DESCRIPTION
Turns out our dynamodb lock library updates the expiry time while holding a lock, so we should grant permission to UpdateItem on the sgtm-lock table

```
Traceback (most recent call last):
File "/var/task/python_dynamodb_lock/python_dynamodb_lock.py", line 225, in _send_heartbeat
':new_et': new_expiry_time,
File "/var/task/boto3/resources/factory.py", line 520, in do_action
response = action(self, *args, **kwargs)
File "/var/task/boto3/resources/action.py", line 83, in __call__
response = getattr(parent.meta.client, operation_name)(**params)
File "/var/task/botocore/client.py", line 276, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/task/botocore/client.py", line 586, in _make_api_call
raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the UpdateItem operation: User: arn:aws:sts::089672317122:assumed-role/iam_for_lambda/sgtm is not authorized to perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:us-east-1:089672317122:table/sgtm-lock
```


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1175880122554645)