### PR TITLE
Expire sgtm-lock items after 1 minute

### DIFF
--- a/src/dynamodb/lock.py
+++ b/src/dynamodb/lock.py
@@ -20,11 +20,9 @@ lock_client = DynamoDBLockClient(
 
 
 @contextmanager
-def dynamodb_lock(lock_name: str, retry_timeout: Optional[timedelta] = None):
-    # The Lambda function has a 30 second timeout by default
-    if retry_timeout is None:
-        retry_timeout = timedelta(seconds=20)
-
+def dynamodb_lock(
+    lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=20)
+):
     # TODO: Make this match get-lock-client in the clojure code
     lock = lock_client.acquire_lock(
         lock_name, sort_key=lock_name, retry_timeout=retry_timeout


### PR DESCRIPTION
The Lambda function has a 30 second timeout, so we should be more aggressive with our expiry times. Also - the retry_timeout should be less than 30 for the same logic.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1175897110302207)