### PR TITLE
Fix sync_users when asana user id is None

### DIFF
--- a/src/sync_users/sgtm_user.py
+++ b/src/sync_users/sgtm_user.py
@@ -51,12 +51,12 @@ class SgtmUser(object):
         asana_user_id = None
         for cf in custom_fields_list:
             if cf["name"] == cls.USER_ID_CUSTOM_FIELD_NAME:
-                asana_user_id = str(cls._get_custom_field_value(cf))
+                asana_user_id = cls._get_custom_field_value(cf)
             elif cf["name"] == cls.GITHUB_HANDLE_CUSTOM_FIELD_NAME:
                 github_handle = cls._get_custom_field_value(cf)
 
         if github_handle and asana_user_id:
-            return cls(github_handle, asana_user_id)
+            return cls(github_handle, str(asana_user_id))
         else:
             return None
 

--- a/test/sync_users/test_sgtm_user.py
+++ b/test/sync_users/test_sgtm_user.py
@@ -60,6 +60,22 @@ class TestSgtmUser(unittest.TestCase):
         user = SgtmUser.from_custom_fields_list(custom_fields)
         self.assertEqual(user, None)
 
+    def test_from_custom_fields_list__None_custom_field_value_returns_None(self):
+        custom_fields = [
+            {
+                "name": SgtmUser.GITHUB_HANDLE_CUSTOM_FIELD_NAME,
+                "type": "text",
+                "text_value": "elainebenes",
+            },
+            {
+                "name": SgtmUser.USER_ID_CUSTOM_FIELD_NAME,
+                "type": "number",
+                "number_value": None,
+            },
+        ]
+        user = SgtmUser.from_custom_fields_list(custom_fields)
+        self.assertEqual(user, None)
+
     def test_equality(self):
         user1 = SgtmUser("Foo", "123")
         user2 = SgtmUser("fOO", "123")


### PR DESCRIPTION
We are casting `None` to a str, so it's coming back as `"None"` and writing that value to the `sgtm-users` table


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1179372790204003)