### PR TITLE
Use pull request id for dynamodb lock in status webhook

### DIFF
--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -106,8 +106,8 @@ def _handle_pull_request_review_comment(payload: dict):
 # https://developer.github.com/v3/activity/events/types/#statusevent
 def _handle_status_webhook(payload: dict):
     commit_id = payload["commit"]["node_id"]
-    with dynamodb_lock(commit_id):
-        pull_request = graphql_client.get_pull_request_for_commit(commit_id)
+    pull_request = graphql_client.get_pull_request_for_commit(commit_id)
+    with dynamodb_lock(pull_request.id()):
         return github_controller.upsert_pull_request(pull_request)
 
 


### PR DESCRIPTION
If a status and pull_request event come around the same time, they both make calls to `upsert_pull_request`, so they should both use the PR node id for the Dynamodb lock. See: https://app.asana.com/0/780306770840675/1179428078499497/f for the bug report


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1179454886419443)