### PR TITLE
Sleep for 1 second before all webhooks

### DIFF
--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -1,5 +1,6 @@
 from typing import Optional
 from operator import itemgetter
+import time
 
 import src.github.graphql.client as graphql_client
 from src.dynamodb.lock import dynamodb_lock
@@ -126,4 +127,12 @@ def handle_github_webhook(event_type, payload):
         return
 
     logger.info(f"Received event type {event_type}!")
+    # TEMPORARY: sleep for 1 second before handling any webhook. We're running
+    # into an issue where the Github Webhook sends us a node_id, but when we
+    # immediately query that id using the GraphQL API, we get back an error
+    # "Could not resolve to a node with the global id of '<node_id>'". This is
+    # an attempt to mitigate this issue temporarily by waiting a second to see
+    # if Github's data consistency needs a bit of time (does not have
+    # read-after-write consistency)
+    time.sleep(1)
     return _events_map[event_type](payload)

--- a/src/handler.py
+++ b/src/handler.py
@@ -3,6 +3,7 @@ import hmac
 import json
 
 from src.config import GITHUB_HMAC_SECRET
+from src.logger import logger
 import src.github.webhook as github_webhook
 
 
@@ -16,6 +17,8 @@ def handler(event: dict, context: dict) -> None:
 
     event_type = event["headers"].get("X-GitHub-Event")
     signature = event["headers"].get("X-Hub-Signature")
+    delivery_id = event["headers"].get("X-GitHub-Delivery")
+    logger.info(f"Webhook delivery id: {delivery_id}")
 
     if GITHUB_HMAC_SECRET is None:
         raise ValueError("GITHUB_HMAC_SECRET")


### PR DESCRIPTION
Trying to debug https://app.asana.com/0/780306770840675/1185945751673053/f, we're seeing that webhooks are delivering with a node id that then can't be queried immediately (but we have confirmed that it can shortly after). This is a temporary hack to try to mitigate the issue.

Also snuck in the delivery id logging, which makes debugging easier


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1185964527181521)