### PR TITLE
Bump sleep to 2 seconds

### DIFF
--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -127,12 +127,12 @@ def handle_github_webhook(event_type, payload):
         return
 
     logger.info(f"Received event type {event_type}!")
-    # TEMPORARY: sleep for 1 second before handling any webhook. We're running
+    # TEMPORARY: sleep for 2 seconds before handling any webhook. We're running
     # into an issue where the Github Webhook sends us a node_id, but when we
     # immediately query that id using the GraphQL API, we get back an error
     # "Could not resolve to a node with the global id of '<node_id>'". This is
     # an attempt to mitigate this issue temporarily by waiting a second to see
     # if Github's data consistency needs a bit of time (does not have
     # read-after-write consistency)
-    time.sleep(1)
+    time.sleep(2)
     return _events_map[event_type](payload)


### PR DESCRIPTION
We're seeing the 1 second sleep help a bunch, but there are still errors every so often. I'm bumping this to 2 seconds for now but want to get to a better solution ideally. Here's the message I got back from GitHub support:


Hi Gregory,

>The problem here is that we used to reliably query for that data right away, where as now (got much work within the last week) we are seeing errors querying for the node that was just sent in that webhook. Here's an example:

>Could not resolve to a node with the global id of 'MDE3OlB1bGxSZXF1ZXN0UmV2aWV3NDU0NTQ5NTIy'.

Thanks for reporting this behaviour, it sounds like something we've only received a few reports for previously. So that we can investigate further and review our logs, could you please let us know the following information:

* The details of one or two webhook deliveries containing a global id that subsequently failed to be resolved.
* The approximate timeframe and timezone for when the above webhooks were triggered and requests for the global id failed.
>then we immediately query the graphql api using that node id to fetch more information that we need.

If possible, please also share the query used above to retrieve additional information using the node id.

> The short-term mitigation I'm trying is to just sleep for 1 second before any graphql queries, but that's not an ideal solution since we still don't know if after that 1 second the data is updated to what the webhook sent.

We do recommended implementing a short sleep (e.g. 2 seconds) between the webhook delivery and the API call to see if that helps. Are you able to extend the sleep further and add a delay to any retries, at least temporarily for testing purposes? We're interested to know if that completely resolves the problem for you.

Please let me know if you have any questions.

Thanks,
Vanessa



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1186070554718238)