### PR TITLE
Find raw URLs and convert to <A></A> wrapped links

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -1,5 +1,5 @@
 import re
-from html import escape
+from html import escape, unescape
 from datetime import datetime, timedelta
 from typing import Callable, Match, Optional, List, Dict
 from src.dynamodb import client as dynamodb_client
@@ -244,9 +244,8 @@ def convert_urls_to_links(text: str) -> str:
     """
 
     def urlreplace(matchobj: Match[str]) -> str:
-        return matchobj.group(1) + _wrap_in_tag("A", attrs={"href": matchobj.group(2)})(
-            matchobj.group(2)
-        )
+        url = unescape(matchobj.group(2))
+        return matchobj.group(1) + _wrap_in_tag("A", attrs={"href": url})(url)
 
     return re.sub(URL_REGEX, urlreplace, text)
 

--- a/test/asana/helpers/test_asana_comment_from_github_comment.py
+++ b/test/asana/helpers/test_asana_comment_from_github_comment.py
@@ -1,3 +1,4 @@
+from html import escape
 import src.asana.helpers
 from test.impl.mock_dynamodb_test_case import MockDynamoDbTestCase
 from test.impl.builders import builder, build
@@ -21,6 +22,20 @@ class TestAsanaCommentFromGitHubComment(MockDynamoDbTestCase):
             github_comment
         )
         self.assertContainsStrings(asana_comment, ["GITHUB_COMMENT_TEXT"])
+
+    def test_transforms_urls_from_comment_tect(self):
+        url = "https://www.foo.bar/?a=1&b=2"
+        github_comment = build(
+            builder.comment()
+            .author(builder.user("github_unknown_user_login"))
+            .body("Can you refer to the documentation at {}".format(url))
+        )
+        asana_comment = src.asana.helpers.asana_comment_from_github_comment(
+            github_comment
+        )
+        self.assertContainsStrings(
+            asana_comment, ['<A href="{}">{}</A>'.format(escape(url), url)]
+        )
 
     def test_includes_asana_comment_author(self):
         github_comment = build(

--- a/test/asana/helpers/test_convert_urls_to_links.py
+++ b/test/asana/helpers/test_convert_urls_to_links.py
@@ -35,6 +35,16 @@ class TestConvertUrlsToLinks(BaseClass):
         input_text = 'Hey check out <A href="https://www.asana.com">https://www.asana.com</A> to work together effortlessly'
         self.assertEqual(input_text, convert_urls_to_links(input_text))
 
+    def test_markdown_wraped_urls_still_get_converted(self):
+        url = "https://app.asana.com/0/0/12345"
+        input_text = "Pull Request synchronized with [Asana task]({})".format(url)
+        self.assertEqual(
+            'Pull Request synchronized with [Asana task](<A href="{}">{}</A>)'.format(
+                url, url
+            ),
+            convert_urls_to_links(input_text),
+        )
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests


### PR DESCRIPTION
See: https://app.asana.com/0/1149418478823393/1188125386076491/f

The new text editor will not auto-linkify URLs unless they are specified as an <A> tag, so SGTM should find links that should be clickable and convert them to <A> tags


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1190634613884268)