### PR TITLE
Add PR number to PR commit title when automerging

### DIFF
--- a/src/github/client.py
+++ b/src/github/client.py
@@ -27,6 +27,6 @@ def merge_pull_request(owner: str, repository: str, number: int, title: str, bod
     pr = _get_pull_request(owner, repository, number)
 
     # we add the PR number to match Github's default squash and merge title style
-    # which we rely on for code review tests
+    # which we rely on for code review tests.
     title_with_number = f"{title} (#{number})"
     pr.merge(commit_title=title_with_number, commit_message=body, merge_method="squash")


### PR DESCRIPTION
Because we didn't have the PR number in the PR title the way that Github does by default, our code review test couldn't look up the PR to make sure it was approved, and it was failing for any commit merged with auto-merge.

https://app.asana.com/0/780306770840675/1195726809580466/f is an example of the issue.

**Test Plan:** I ran it in the python console and reverted my git pr changes (since they were made using auto-merge and had this issue) and re-merged them with this new behavior and passed the code review test.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1195752639674993)