### PR TITLE
Parse URLs as links in PR reviews

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -331,8 +331,8 @@ def asana_comment_from_github_review(review: Review) -> str:
             _review_action_to_text_map.get(review.state(), "commented")
         )
 
-    review_body = _transform_github_mentions_to_asana_mentions(
-        escape(review.body(), quote=False)
+    review_body = convert_urls_to_links(
+        _transform_github_mentions_to_asana_mentions(escape(review.body(), quote=False))
     )
     if review_body:
         header = (
@@ -346,8 +346,10 @@ def asana_comment_from_github_review(review: Review) -> str:
     inline_comments = [
         _wrap_in_tag("li")(
             _wrap_in_tag("A", attrs={"href": comment.url()})(f"[{i}] ")
-            + _transform_github_mentions_to_asana_mentions(
-                escape(comment.body(), quote=False)
+            + convert_urls_to_links(
+                _transform_github_mentions_to_asana_mentions(
+                    escape(comment.body(), quote=False)
+                )
             )
         )
         for i, comment in enumerate(review.comments(), start=1)

--- a/test/asana/helpers/test_asana_comment_from_github_review.py
+++ b/test/asana/helpers/test_asana_comment_from_github_review.py
@@ -34,6 +34,25 @@ class TestAsanaCommentFromGitHubReview(MockDynamoDbTestCase):
             asana_review_comment, ["GITHUB_REVIEW_TEXT", "GITHUB_REVIEW_COMMENT_TEXT"]
         )
 
+    def test_converts_urls_to_links(self):
+        github_review = build(
+            builder.review()
+            .author(builder.user("github_unknown_user_login"))
+            .state(ReviewState.DEFAULT)
+            .body("https://www.asana.com")
+            .comment(builder.comment().body("http://www.foo.com"))
+        )
+        asana_review_comment = src.asana.helpers.asana_comment_from_github_review(
+            github_review
+        )
+        self.assertContainsStrings(
+            asana_review_comment,
+            [
+                '<A href="{}">{}</A>'.format(url, url)
+                for url in ["https://www.asana.com", "http://www.foo.com"]
+            ],
+        )
+
     def test_handles_no_review_text(self):
         github_review = build(
             builder.review()


### PR DESCRIPTION
This was happening already for comments and PR descriptions, but was missed for reviews. See: https://app.asana.com/0/780306770840675/1197573430609585/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1198219866803732)