### PR TITLE
Update CircleCI to take advantage of python dependency cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,8 @@ commands:
   setup:
     steps:
       - checkout
-      - run: pip install -r requirements.txt
-      - run: pip install -r requirements-dev.txt
+      - python/install-packages:
+          args: -r requirements.txt -r requirements-dev.txt
 
 jobs:
   black:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ commands:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-          args: -r requirements.txt -r requirements-dev.txt
+          args: -r requirements-dev.txt
 
 jobs:
   black:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ commands:
     steps:
       - checkout
       - python/install-packages:
+          pkg-manager: pip
           args: -r requirements.txt -r requirements-dev.txt
 
 jobs:


### PR DESCRIPTION
Use the Python orb's `python/install-packages' rather than manually running `pip` in the setup


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1200330168761457)