### PR TITLE
Update automerge comment warning logic to use new label as well

### DIFF
--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -165,9 +165,11 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
         # only add warning comment if it's set to auto-merge after approval and hasn't yet been approved to limit noise
 
         if (
-            _pull_request_has_automerge_label(pull_request)
-            and pull_request_has_label(
+            (pull_request_has_label(
                 pull_request, AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value
+            ) or
+            pull_request_has_label(pull_request, AutomergeLabel.AFTER_APPROVAL.value)
+
             )
             and not _pull_request_has_automerge_comment(pull_request)
             and not pull_request.is_approved()
@@ -233,15 +235,6 @@ def _is_pull_request_ready_for_automerge(pull_request: PullRequest) -> bool:
         return pull_request.is_mergeable() and pull_request.is_approved()
 
     return False
-
-
-def _pull_request_has_automerge_label(pull_request: PullRequest) -> bool:
-    return any(
-        map(
-            lambda label: pull_request_has_label(pull_request, label.value),
-            AutomergeLabel,
-        )
-    )
 
 
 def _pull_request_has_automerge_comment(pull_request: PullRequest) -> bool:

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -165,11 +165,13 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
         # only add warning comment if it's set to auto-merge after approval and hasn't yet been approved to limit noise
 
         if (
-            (pull_request_has_label(
-                pull_request, AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value
-            ) or
-            pull_request_has_label(pull_request, AutomergeLabel.AFTER_APPROVAL.value)
-
+            (
+                pull_request_has_label(
+                    pull_request, AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value
+                )
+                or pull_request_has_label(
+                    pull_request, AutomergeLabel.AFTER_APPROVAL.value
+                )
             )
             and not _pull_request_has_automerge_comment(pull_request)
             and not pull_request.is_approved()

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -98,24 +98,24 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
     def test_adds_warnings_if_label_and_no_warning_in_comments(
         self, add_pr_comment_mock, edit_pr_title_mock
     ):
-        pull_request = build(
-            builder.pull_request()
-            .title(self.SAMPLE_PR_TITLE)
-            .label(
-                builder.label().name(
-                    github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value
-                )
+        for label in [
+            github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value,
+            github_logic.AutomergeLabel.AFTER_APPROVAL.value,
+        ]:
+            pull_request = build(
+                builder.pull_request()
+                .title(self.SAMPLE_PR_TITLE)
+                .label(builder.label().name(label))
             )
-        )
 
-        github_logic.maybe_add_automerge_warning_comment(pull_request)
+            github_logic.maybe_add_automerge_warning_comment(pull_request)
 
-        add_pr_comment_mock.assert_called_with(
-            pull_request.repository_owner_handle(),
-            pull_request.repository_name(),
-            pull_request.number(),
-            github_logic.AUTOMERGE_COMMENT_WARNING,
-        )
+            add_pr_comment_mock.assert_called_with(
+                pull_request.repository_owner_handle(),
+                pull_request.repository_name(),
+                pull_request.number(),
+                github_logic.AUTOMERGE_COMMENT_WARNING,
+            )
 
     @patch("src.github.logic.SGTM_FEATURE__AUTOMERGE_ENABLED", True)
     def test_does_not_add_warning_if_has_label_and_already_has_warning_in_comments(


### PR DESCRIPTION
Now that we've added a new label for "merge after approval" (#98) -- the warning comment should apply here as well.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1200461990674320)