### PR TITLE
Escape extra bracket in block quote

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -13,7 +13,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return text + "\n"
 
     def block_quote(self, text):
-        return f"<em>> {escape(text, quote=False)}</em>"
+        return f"<em>{escape('> ' + text, quote=False)}</em>"
 
     def strikethrough(self, text):
         return f"<s>{escape(text, quote=False)}</s>"

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -30,11 +30,18 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
         return re.sub(URL_REGEX, urlreplace, text)
 
+    # Asana's API can't handle img tags
+    def image(self, src, alt="", title=None):
+        return None
+
 
 def convert_github_markdown_to_asana_xml(text: str) -> str:
     markdown = mistune.create_markdown(
         renderer=GithubToAsanaRenderer(escape=False), plugins=["strikethrough"],
     )
+
+    # remove html tags since we don't know if the Asana API can handle them
+    text = re.sub("<[^<]+?>", "", text)
     return _strip_pre_tags(markdown(text))
 
 

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -34,7 +34,7 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
     def test_block_quote(self):
         md = "> block quote"
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, "<em>> block quote\n</em>")
+        self.assertEqual(xml, "<em>&gt; block quote\n</em>")
 
     def test_auto_linking(self):
         md = "https://asana.com/ [still works](www.test.com)"

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -54,6 +54,11 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<code>test</code>\n")
 
+    def test_removes_html(self):
+        md = """<img href='link' />still here <h3>header</h3>"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, "still here header\n")
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests


### PR DESCRIPTION
Adding in an extra `>` will cause the Asana html parser to break -- this should be escaped


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1200725692785455)