### PR TITLE
Add better parsing for images in markdown

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -250,6 +250,7 @@ def _extract_attachments(body_text: str) -> List[AttachmentData]:
     """
     attachments = []
     matches = re.findall(github_logic.GITHUB_ATTACHMENT_REGEX, body_text)
+    print("matches", matches)
     for img_name, img_url, img_ext in matches:
         image_type = _image_extension_to_type.get(img_ext)
 
@@ -264,7 +265,10 @@ def _extract_attachments(body_text: str) -> List[AttachmentData]:
 
 
 def create_attachments(body_text: str, task_id: str) -> None:
+    print("here")
     attachments = _extract_attachments(body_text)
+    print("attachments")
+    print(attachments)
     for attachment in attachments:
         try:
             with urllib.request.urlopen(attachment.file_url) as f:

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -250,7 +250,6 @@ def _extract_attachments(body_text: str) -> List[AttachmentData]:
     """
     attachments = []
     matches = re.findall(github_logic.GITHUB_ATTACHMENT_REGEX, body_text)
-    print("matches", matches)
     for img_name, img_url, img_ext in matches:
         image_type = _image_extension_to_type.get(img_ext)
 
@@ -265,10 +264,7 @@ def _extract_attachments(body_text: str) -> List[AttachmentData]:
 
 
 def create_attachments(body_text: str, task_id: str) -> None:
-    print("here")
     attachments = _extract_attachments(body_text)
-    print("attachments")
-    print(attachments)
     for attachment in attachments:
         try:
             with urllib.request.urlopen(attachment.file_url) as f:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -32,7 +32,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
     # Asana's API can't handle img tags
     def image(self, src, alt="", title=None):
-        return None
+        return f'<a href="{src}">{alt}</a>'
 
 
 def convert_github_markdown_to_asana_xml(text: str) -> str:

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -59,6 +59,11 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "still here header\n")
 
+    def test_removes_images(self):
+        md = """![image](https://image.com)"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, '<a href="https://image.com">image</a>\n')
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests


### PR DESCRIPTION
We were failing on markdown formatted images because we were returning None from our renderer, which it doesn't like. We now return a link to the image, which is better anyway and also shouldn't error.

See https://github.com/Asana/codez/pull/110935#issuecomment-838773257 for an example


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1200733730842313)