### PR TITLE
Fallback to statusCheckRollup when status is none

### DIFF
--- a/src/github/graphql/fragments/FullPullRequest.py
+++ b/src/github/graphql/fragments/FullPullRequest.py
@@ -70,6 +70,9 @@ fragment FullPullRequest on PullRequest {
         status {
           state
         }
+        statusCheckRollup {
+          state
+        }
       }
     }
   }

--- a/src/github/models/commit.py
+++ b/src/github/models/commit.py
@@ -14,6 +14,9 @@ class Commit(object):
     def status(self) -> Optional[str]:
         status = self._raw["commit"].get("status")
         if status is None:
+            status = self._raw["commit"].get("statusCheckRollup")
+
+        if status is None:
             return None
         else:
             return status.get("state", None)


### PR DESCRIPTION
On some repos, we're seeing [this issue](https://github.community/t/graphql-api-response-for-commit-status-is-null/13762/6) - so falling back to statusCheckRollup seems to do the trick

Fixes: https://app.asana.com/0/1149418478823393/1200751774126749/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1200991024698718)