### PR TITLE
Improve markdown parsing

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -13,17 +13,23 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return text + "\n"
 
     def block_quote(self, text):
-        return f"<em>{escape('> ' + text, quote=False)}</em>"
+        return f"<em>&gt; {text}</em>"
 
     def strikethrough(self, text):
-        return f"<s>{escape(text, quote=False)}</s>"
+        return f"<s>{text}</s>"
 
     def heading(self, text, level):
-        return f"\n<b>{escape(text, quote=False)}</b>\n"
+        return f"\n<b>{text}</b>\n"
 
     def thematic_break(self):
         # Asana API doesn't not support <hr />
         return "\n---\n"
+
+    def inline_html(self, html):
+        return escape(html)
+
+    def codespan(self, text):
+        return '<code>' + escape(text) + '</code>'
 
     def text(self, text):
         text = escape(text, quote=False)
@@ -44,8 +50,6 @@ def convert_github_markdown_to_asana_xml(text: str) -> str:
         renderer=GithubToAsanaRenderer(escape=False), plugins=["strikethrough"],
     )
 
-    # remove html tags since we don't know if the Asana API can handle them
-    text = re.sub("<[^<]+?>", "", text)
     return _strip_pre_tags(markdown(text))
 
 

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -22,7 +22,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return f"\n<b>{text}</b>\n"
 
     def thematic_break(self) -> str:
-        # Asana API doesn't not support <hr />
+        # Asana API doesn't support <hr />
         return "\n---\n"
 
     def inline_html(self, html) -> str:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -9,29 +9,29 @@ URL_REGEX = r"""(?i)([^"\>\<\/\.]|^)\b((?:https?:(/{1,3}))(?:[^\s()<>{}\[\]]+|\(
 
 
 class GithubToAsanaRenderer(mistune.HTMLRenderer):
-    def paragraph(self, text):
+    def paragraph(self, text) -> str:
         return text + "\n"
 
-    def block_quote(self, text):
+    def block_quote(self, text) -> str:
         return f"<em>&gt; {text}</em>"
 
-    def strikethrough(self, text):
+    def strikethrough(self, text) -> str:
         return f"<s>{text}</s>"
 
-    def heading(self, text, level):
+    def heading(self, text, level) -> str:
         return f"\n<b>{text}</b>\n"
 
-    def thematic_break(self):
+    def thematic_break(self) -> str:
         # Asana API doesn't not support <hr />
         return "\n---\n"
 
-    def inline_html(self, html):
+    def inline_html(self, html) -> str:
         return escape(html)
 
-    def codespan(self, text):
-        return '<code>' + escape(text) + '</code>'
+    def codespan(self, text) -> str:
+        return "<code>" + escape(text) + "</code>"
 
-    def text(self, text):
+    def text(self, text) -> str:
         text = escape(text, quote=False)
 
         def urlreplace(matchobj: Match[str]) -> str:
@@ -41,7 +41,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return re.sub(URL_REGEX, urlreplace, text)
 
     # Asana's API can't handle img tags
-    def image(self, src, alt="", title=None):
+    def image(self, src, alt="", title=None) -> str:
         return f'<a href="{src}">{alt}</a>'
 
 

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -69,12 +69,22 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
     def test_escapes_raw_html_mixed_with_markdown(self):
         md = """## <img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, "\n<b>" + escape("<img href=\"link\" />")  + "still here " + escape("<h3>header</h3>") + "</b>\n")
+        self.assertEqual(
+            xml,
+            "\n<b>"
+            + escape('<img href="link" />')
+            + "still here "
+            + escape("<h3>header</h3>")
+            + "</b>\n",
+        )
 
     def test_escapes_raw_html(self):
         md = """<img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, escape("<img href=\"link\" />") + "still here " + escape("<h3>header</h3>\n"))
+        self.assertEqual(
+            xml,
+            escape('<img href="link" />') + "still here " + escape("<h3>header</h3>\n"),
+        )
 
     def test_removes_images(self):
         md = """![image](https://image.com)"""

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,5 +1,6 @@
 import unittest
 
+from html import escape
 from src.markdown_parser import convert_github_markdown_to_asana_xml
 
 
@@ -55,15 +56,25 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "\n<b>heading</b>\n")
 
+    def test_nested_code_within_block_quote(self):
+        md = "> abc `123`"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, "<em>&gt; abc <code>123</code>\n</em>")
+
     def test_removes_pre_tags(self):
         md = """```test```"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<code>test</code>\n")
 
-    def test_removes_html(self):
-        md = """<img href='link' />still here <h3>header</h3>"""
+    def test_escapes_raw_html_mixed_with_markdown(self):
+        md = """## <img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, "still here header\n")
+        self.assertEqual(xml, "\n<b>" + escape("<img href=\"link\" />")  + "still here " + escape("<h3>header</h3>") + "</b>\n")
+
+    def test_escapes_raw_html(self):
+        md = """<img href="link" />still here <h3>header</h3>"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, escape("<img href=\"link\" />") + "still here " + escape("<h3>header</h3>\n"))
 
     def test_removes_images(self):
         md = """![image](https://image.com)"""


### PR DESCRIPTION
Fix a few reported bugs with nested markdown parsing (see: https://app.asana.com/0/780306770840675/1200944119020029/f and https://app.asana.com/0/780306770840675/1200842082019847/f)

Biggest change here is to no longer blindly strip all `<` and `>`, and add an `inline_html` function as a catch-all for these and escape the html.

Added some test cases from the reported bugs


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1201049190615122)