### PR TITLE
Markdown improvements, take two

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -28,6 +28,9 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     def inline_html(self, html) -> str:
         return escape(html)
 
+    def block_html(self, html) -> str:
+        return escape(html)
+
     def codespan(self, text) -> str:
         return "<code>" + escape(text) + "</code>"
 
@@ -50,9 +53,4 @@ def convert_github_markdown_to_asana_xml(text: str) -> str:
         renderer=GithubToAsanaRenderer(escape=False), plugins=["strikethrough"],
     )
 
-    return _strip_pre_tags(markdown(text))
-
-
-# the Asana API doesn't accept pre tags so we strip them
-def _strip_pre_tags(text: str) -> str:
-    return text.replace("<pre>", "").replace("</pre>", "")
+    return markdown(text)

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -9,23 +9,29 @@ URL_REGEX = r"""(?i)([^"\>\<\/\.]|^)\b((?:https?:(/{1,3}))(?:[^\s()<>{}\[\]]+|\(
 
 
 class GithubToAsanaRenderer(mistune.HTMLRenderer):
-    def paragraph(self, text):
+    def paragraph(self, text) -> str:
         return text + "\n"
 
-    def block_quote(self, text):
-        return f"<em>{escape('> ' + text, quote=False)}</em>"
+    def block_quote(self, text) -> str:
+        return f"<em>&gt; {text}</em>"
 
-    def strikethrough(self, text):
-        return f"<s>{escape(text, quote=False)}</s>"
+    def strikethrough(self, text) -> str:
+        return f"<s>{text}</s>"
 
-    def heading(self, text, level):
-        return f"\n<b>{escape(text, quote=False)}</b>\n"
+    def heading(self, text, level) -> str:
+        return f"\n<b>{text}</b>\n"
 
-    def thematic_break(self):
-        # Asana API doesn't not support <hr />
+    def thematic_break(self) -> str:
+        # Asana API doesn't support <hr />
         return "\n---\n"
 
-    def text(self, text):
+    def inline_html(self, html) -> str:
+        return escape(html)
+
+    def codespan(self, text) -> str:
+        return "<code>" + escape(text) + "</code>"
+
+    def text(self, text) -> str:
         text = escape(text, quote=False)
 
         def urlreplace(matchobj: Match[str]) -> str:
@@ -35,7 +41,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return re.sub(URL_REGEX, urlreplace, text)
 
     # Asana's API can't handle img tags
-    def image(self, src, alt="", title=None):
+    def image(self, src, alt="", title=None) -> str:
         return f'<a href="{src}">{alt}</a>'
 
 
@@ -44,8 +50,6 @@ def convert_github_markdown_to_asana_xml(text: str) -> str:
         renderer=GithubToAsanaRenderer(escape=False), plugins=["strikethrough"],
     )
 
-    # remove html tags since we don't know if the Asana API can handle them
-    text = re.sub("<[^<]+?>", "", text)
     return _strip_pre_tags(markdown(text))
 
 

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,5 +1,6 @@
 import unittest
 
+from html import escape
 from src.markdown_parser import convert_github_markdown_to_asana_xml
 
 
@@ -55,15 +56,35 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "\n<b>heading</b>\n")
 
+    def test_nested_code_within_block_quote(self):
+        md = "> abc `123`"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, "<em>&gt; abc <code>123</code>\n</em>")
+
     def test_removes_pre_tags(self):
         md = """```test```"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<code>test</code>\n")
 
-    def test_removes_html(self):
-        md = """<img href='link' />still here <h3>header</h3>"""
+    def test_escapes_raw_html_mixed_with_markdown(self):
+        md = """## <img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, "still here header\n")
+        self.assertEqual(
+            xml,
+            "\n<b>"
+            + escape('<img href="link" />')
+            + "still here "
+            + escape("<h3>header</h3>")
+            + "</b>\n",
+        )
+
+    def test_escapes_raw_html(self):
+        md = """<img href="link" />still here <h3>header</h3>"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            escape('<img href="link" />') + "still here " + escape("<h3>header</h3>\n"),
+        )
 
     def test_removes_images(self):
         md = """![image](https://image.com)"""

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -88,7 +88,7 @@ still here <h3>header</h3>"""
             "\n<b>blah blah blah</b>\n"
             + escape('<img href="link">\n')
             + "still here "
-            + escape("<h3>header</h3>")
+            + escape("<h3>header</h3>"),
         )
 
     def test_escapes_raw_html(self):

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -78,6 +78,19 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
             + "</b>\n",
         )
 
+    def test_escapes_raw_html_on_own_lines(self):
+        md = """## blah blah blah
+<img href="link">
+still here <h3>header</h3>"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            "\n<b>blah blah blah</b>\n"
+            + escape('<img href="link">\n')
+            + "still here "
+            + escape("<h3>header</h3>")
+        )
+
     def test_escapes_raw_html(self):
         md = """<img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)


### PR DESCRIPTION
#106 had to be reverted due to improper handling of block html - but I think we should be good to go now with addition of `block_html` and an additional test. This PR reverts #107 as well.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1201058999228386)