### PR TITLE
Strip <pre> tags for block_code

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -34,6 +34,11 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     def codespan(self, text) -> str:
         return "<code>" + escape(text) + "</code>"
 
+    def block_code(self, code, info=None):
+        html = super().block_code(code, info=info)
+        # the Asana API doesn't accept pre tags so we strip them
+        return html.replace("<pre>", "").replace("</pre>", "")
+
     def text(self, text) -> str:
         text = escape(text, quote=False)
 

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -61,10 +61,19 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<em>&gt; abc <code>123</code>\n</em>")
 
-    def test_removes_pre_tags(self):
+    def test_removes_pre_tags_inline(self):
         md = """```test```"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<code>test</code>\n")
+
+    def test_removes_pre_tags_block(self):
+        md = """see:
+```
+function foo = () => null;
+```
+"""
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(xml, "see:\n<code>function foo = () =&gt; null;\n</code>\n")
 
     def test_escapes_raw_html_mixed_with_markdown(self):
         md = """## <img href="link" />still here <h3>header</h3>"""


### PR DESCRIPTION
In #108  I removed the function that strips `<pre>` tags because I wasn't sure where they were being used... Now I realize it was for code blocks - so I inlined it just in that function to make it clear why it's being used.

For the default implementation see: https://github.com/lepture/mistune/blob/46a65a978b005651dcc54a340e44aef71f9f7e95/mistune/renderers.py#L188




Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1201072278684769)