### PR TITLE
Add support for check_suite webhook

### DIFF
--- a/src/github/graphql/client.py
+++ b/src/github/graphql/client.py
@@ -33,8 +33,13 @@ def get_pull_request(pull_request_id: str) -> PullRequest:
     return PullRequest(data["pullRequest"])
 
 
-def get_pull_request_by_id_number(repository_owner: str, repository_name: str, pull_request_id: int) -> PullRequest:
-    data = _execute_graphql_query(GetPullRequestByIdNumber, {"owner": repository_owner, "name": repository_name, "number": pull_request_id})
+def get_pull_request_by_id_number(
+    repository_owner: str, repository_name: str, pull_request_id: int
+) -> PullRequest:
+    data = _execute_graphql_query(
+        GetPullRequestByIdNumber,
+        {"owner": repository_owner, "name": repository_name, "number": pull_request_id},
+    )
     return PullRequest(data["repository"]["pullRequest"])
 
 

--- a/src/github/graphql/client.py
+++ b/src/github/graphql/client.py
@@ -4,6 +4,7 @@ from src.config import GITHUB_API_KEY
 from src.github.models import comment_factory, PullRequest, Review, Comment
 from .queries import (
     GetPullRequest,
+    GetPullRequestByIdNumber,
     GetPullRequestAndComment,
     GetPullRequestAndReview,
     GetPullRequestForCommit,
@@ -30,6 +31,11 @@ def _execute_graphql_query(query: FrozenSet[str], variables: dict) -> dict:
 def get_pull_request(pull_request_id: str) -> PullRequest:
     data = _execute_graphql_query(GetPullRequest, {"id": pull_request_id})
     return PullRequest(data["pullRequest"])
+
+
+def get_pull_request_by_id_number(repository_owner: str, repository_name: str, pull_request_id: int) -> PullRequest:
+    data = _execute_graphql_query(GetPullRequestByIdNumber, {"owner": repository_owner, "name": repository_name, "number": pull_request_id})
+    return PullRequest(data["repository"]["pullRequest"])
 
 
 def get_pull_request_and_comment(

--- a/src/github/graphql/queries/GetPullRequestByIdNumber.py
+++ b/src/github/graphql/queries/GetPullRequestByIdNumber.py
@@ -1,0 +1,20 @@
+from typing import FrozenSet
+from ..fragments import FullPullRequest, FullReview
+
+# @GraphqlInPython
+_get_pull_request_by_id_number = """
+query GetPullRequestByIdNumber($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      __typename
+      ... on PullRequest {
+        ...FullPullRequest
+      }
+    }
+  }
+}
+"""
+
+GetPullRequestByIdNumber: FrozenSet[str] = frozenset(
+    [_get_pull_request_by_id_number]
+) | FullPullRequest | FullReview

--- a/src/github/graphql/queries/__init__.py
+++ b/src/github/graphql/queries/__init__.py
@@ -1,4 +1,5 @@
 from .GetPullRequest import GetPullRequest
+from .GetPullRequestByIdNumber import GetPullRequestByIdNumber
 from .GetPullRequestAndComment import GetPullRequestAndComment
 from .GetPullRequestAndReview import GetPullRequestAndReview
 from .GetPullRequestForCommit import GetPullRequestForCommit

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -11,7 +11,7 @@ from src.logger import logger
 from src.github.models import PullRequestReviewComment, Review
 
 
-# https://developer.github.com/v3/activity/events/types/#pullrequestevent
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
 def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
     with dynamodb_lock(pull_request_id):
@@ -23,7 +23,7 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
         return HttpResponse("200")
 
 
-# https://developer.github.com/v3/activity/events/types/#issuecommentevent
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
 def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
     action, issue, comment = itemgetter("action", "issue", "comment")(payload)
 
@@ -46,7 +46,7 @@ def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
             return HttpResponse("400", error_text)
 
 
-# https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review
 def _handle_pull_request_review_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
     review_id = payload["review"]["node_id"]
@@ -60,7 +60,7 @@ def _handle_pull_request_review_webhook(payload: dict) -> HttpResponse:
     return HttpResponse("200")
 
 
-# https://developer.github.com/v3/activity/events/types/#pullrequestreviewcommentevent
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request_review_comment
 def _handle_pull_request_review_comment(payload: dict):
     """Handle when a pull request review comment is edited or removed.
     When comments are added it either hits:
@@ -118,7 +118,7 @@ def _handle_pull_request_review_comment(payload: dict):
         return HttpResponse("200")
 
 
-# https://developer.github.com/v3/activity/events/types/#statusevent
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#status
 def _handle_status_webhook(payload: dict) -> HttpResponse:
     commit_id = payload["commit"]["node_id"]
     pull_request = graphql_client.get_pull_request_for_commit(commit_id)
@@ -134,12 +134,31 @@ def _handle_status_webhook(payload: dict) -> HttpResponse:
         return HttpResponse("200")
 
 
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite
+def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
+    pull_requests = payload["check_suite"]["pull_requests"]
+    if len(pull_requests) == 0:
+        return HttpResponse("400", error_text)
+
+    pull_request_id = pull_requests[0]["id"]
+    repository_owner = payload["repository"]["owner"]["login"]
+    repository_name = payload["repository"]["name"]
+
+    pull_request = graphql_client.get_pull_request_by_id_number(repository_owner, repository_name, pull_request_id)
+
+    with dynamodb_lock(pull_request.id()):
+        github_logic.maybe_automerge_pull_request(pull_request)
+        github_controller.upsert_pull_request(pull_request)
+        return HttpResponse("200")
+
+
 _events_map = {
     "pull_request": _handle_pull_request_webhook,
     "issue_comment": _handle_issue_comment_webhook,
     "pull_request_review": _handle_pull_request_review_webhook,
     "status": _handle_status_webhook,
     "pull_request_review_comment": _handle_pull_request_review_comment,
+    "check_suite": _handle_check_suite_webhook,
 }
 
 

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -140,6 +140,7 @@ def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
     if len(pull_requests) == 0:
         return HttpResponse("400", "No Pull Request Found")
 
+    # TODO: How to handle multiple PRs?
     pull_request_id = pull_requests[0]["id"]
     repository_owner = payload["repository"]["owner"]["login"]
     repository_name = payload["repository"]["name"]

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -138,7 +138,7 @@ def _handle_status_webhook(payload: dict) -> HttpResponse:
 def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
     pull_requests = payload["check_suite"]["pull_requests"]
     if len(pull_requests) == 0:
-        return HttpResponse("400", error_text)
+        return HttpResponse("400", "No Pull Request Found")
 
     pull_request_id = pull_requests[0]["id"]
     repository_owner = payload["repository"]["owner"]["login"]

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -144,7 +144,9 @@ def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
     repository_owner = payload["repository"]["owner"]["login"]
     repository_name = payload["repository"]["name"]
 
-    pull_request = graphql_client.get_pull_request_by_id_number(repository_owner, repository_name, pull_request_id)
+    pull_request = graphql_client.get_pull_request_by_id_number(
+        repository_owner, repository_name, pull_request_id
+    )
 
     with dynamodb_lock(pull_request.id()):
         github_logic.maybe_automerge_pull_request(pull_request)


### PR DESCRIPTION
Add support for the `check_suite` webhook action, which should have a similar effect as the `status` webhook action, but the GitHub payload is slightly different


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1201915596131251)