### PR TITLE
remove wrapping of inline comments in <ul>

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -350,14 +350,12 @@ def asana_comment_from_github_review(review: Review) -> str:
 
     # For each comment, prefix its text with a bracketed number that is a link to the Github comment.
     inline_comments = [
-        _wrap_in_tag("li")(
             _wrap_in_tag("A", attrs={"href": comment.url()})(f"[{i}] ")
             + _format_github_text_for_asana(comment.body())
-        )
         for i, comment in enumerate(review.comments(), start=1)
     ]
     if inline_comments:
-        comments_html = _wrap_in_tag("ul")("".join(inline_comments))
+        comments_html = "\n\n".join(inline_comments)
         if not review.is_just_comments():
             # If this was an inline reply, we already added "and left inline comments" above.
             comments_html = (

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -355,7 +355,7 @@ def asana_comment_from_github_review(review: Review) -> str:
         for i, comment in enumerate(review.comments(), start=1)
     ]
     if inline_comments:
-        comments_html = "\n\n".join(inline_comments)
+        comments_html = "\n".join(inline_comments)
         if not review.is_just_comments():
             # If this was an inline reply, we already added "and left inline comments" above.
             comments_html = (

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -350,8 +350,8 @@ def asana_comment_from_github_review(review: Review) -> str:
 
     # For each comment, prefix its text with a bracketed number that is a link to the Github comment.
     inline_comments = [
-            _wrap_in_tag("A", attrs={"href": comment.url()})(f"[{i}] ")
-            + _format_github_text_for_asana(comment.body())
+        _wrap_in_tag("A", attrs={"href": comment.url()})(f"[{i}] ")
+        + _format_github_text_for_asana(comment.body())
         for i, comment in enumerate(review.comments(), start=1)
     ]
     if inline_comments:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -31,6 +31,9 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     def block_html(self, html) -> str:
         return escape(html)
 
+    def linebreak(self) -> str:
+        return "\n"
+
     def codespan(self, text) -> str:
         return "<code>" + escape(text) + "</code>"
 


### PR DESCRIPTION
This was causing parsing issues for inline html within an inline comment - and added unnecessary complexity for not much benefit. This removes the `<ul>` list of inline comments for a GH comment and separates them out by newlines instead.

fixes: https://app.asana.com/0/1149418478823393/1201442536592555/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1202038153443517)