### PR TITLE
Clarify action to close post-merge review

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black==19.10b0
 moto==1.3.10
 mypy==0.790
+click==8.0.4 # temp fix for black: https://github.com/psf/black/issues/2964

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -424,7 +424,8 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
     else:
         return StatusReason(
             False,
-            "the pull request hasn't yet been approved by a reviewer after merging.",
+            "the pull request hasn't yet been approved by a reviewer after merging. "
+            + 'The reviewer can close this task by commenting "LGTM" on the Pull Request.',
         )
 
 


### PR DESCRIPTION
It's not clear what the action item is when the Asana task is open but the PR has already been merged. This adds a description of what the reviewer can do to have the task closed properly by SGTM

Fixes: https://app.asana.com/0/780306770840675/1201898061902803/f

Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1202042894235339)