### PR TITLE
add "Draft" as PR Status option

### DIFF
--- a/docs/code_reviews.md
+++ b/docs/code_reviews.md
@@ -19,7 +19,7 @@ Field mapping, GitHub to Asana:
 | PR comment                                        | comment in Asana task. Comes from bot, but `@-mentions` comment author in Asana |
 | PR review                                         | comment in Asana task. Comes from bot, but `@-mentions` review author in Asana |
 | PR participants (author + reviewers + commenters) | followers in Asana task                                      |
-| PR status (open/closed/merged)                    | "PR Status" custom field in Asana task
+| PR status (open/draft/closed/merged)              | "PR Status" custom field in Asana task
 | PR build status (pending/success/failure)         | "Build" custom field in Asana task
 
 #### How a GitHub Pull Request looks like

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -25,6 +25,7 @@ CUSTOM_FIELDS = [
         name="PR Status",
         enum_options=[
             EnumOption(name="Open", color="green"),
+            EnumOption(name="Draft", color="grey"),
             EnumOption(name="Merged", color="purple"),
             EnumOption(name="Closed", color="red"),
         ],

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -75,7 +75,9 @@ def default_due_date_str(reference_datetime: datetime = None) -> str:
 
 
 def _task_status_from_pull_request(pull_request: PullRequest) -> str:
-    if not pull_request.closed():
+    if not pull_request.closed() and pull_request.is_draft():
+        return "Draft"
+    elif not pull_request.closed() and not pull_request.is_draft():
         return "Open"
     elif pull_request.closed() and pull_request.merged():
         return "Merged"
@@ -100,7 +102,7 @@ _custom_fields_to_extract_map = {
 def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     """
     We currently expect the project to have two custom fields with its corresponding enum options:
-        • PR Status: "Open", "Closed", "Merged"
+        • PR Status: "Open", "Draft", "Closed", "Merged"
         • Build: "Success", "Failure"
     """
     repository_id = pull_request.repository_id()

--- a/src/github/graphql/fragments/FullPullRequest.py
+++ b/src/github/graphql/fragments/FullPullRequest.py
@@ -13,6 +13,7 @@ fragment FullPullRequest on PullRequest {
   }
   closed
   merged
+  isDraft
   mergedAt
   mergeable
   url

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -145,6 +145,9 @@ class PullRequest(object):
     def is_mergeable(self) -> bool:
         return self.mergeable() == MergeableState.MERGEABLE
 
+    def is_draft(self) -> bool:
+        return self._raw["isDraft"]
+
     # A PR is considered approved if it has at least one approval and every time changes were requested by a reviewer
     # that same reviewer later approved.
     def is_approved(self) -> bool:


### PR DESCRIPTION
This PR:
- pulls in and exposes the `isDraft` field from the GitHub graphql PR object
- uses said field to determine if the "Draft" option of the "PR Status" field should be selected
- creates "Draft" as an option in the setup script
- No changes need to be made to our automerging logic as a PR being a draft is already included in a PR not being mergable

Consideration was given to adding "Draft" as an option to the "PR Status" field if, when attempting to select this option, it was not present. Ultimately, I felt this added too much complexity to the code and introduced unnecessary mingling of concerns. Instead, we will fail silently to set the field's option. We can add the option manually in Asana's SGTM projects. 

Projects that do not have the "Draft" option should still have the benefit of seeing the custom field change from nothing to "Open" when a PR is changed to or from a draft.