### PR TITLE
Use data-asana-dynamic=false for Asana links with alt text

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -57,9 +57,6 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         # https://developers.asana.com/docs/rich-text
 
         is_asana_vanity_link = link.startswith("https://app.asana.com") and text
-        if text is None:
-            text = link
-
         asana_tags = 'data-asana-dynamic="false" ' if is_asana_vanity_link else ""
         s = "<a " + asana_tags + 'href="' + self._safe_url(link) + '"'
         return s + ">" + (text or link) + "</a>"

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -51,9 +51,21 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
         return re.sub(URL_REGEX, urlreplace, text)
 
+    def link(self, link, text=None, title=None):
+        is_asana_vanity_link = link.startswith("https://app.asana.com") and text is not None
+        if text is None:
+            text = link
+
+        asana_tags = 'data-asana-dynamic="false" ' if is_asana_vanity_link else ""
+        s = '<a ' + asana_tags + 'href="' + self._safe_url(link) + '"'
+        if title:
+            s += ' title="' + mistune.escape_html(title) + '"'
+        return s + '>' + (text or link) + '</a>'
+
     # Asana's API can't handle img tags
     def image(self, src, alt="", title=None) -> str:
-        return f'<a href="{src}">{alt}</a>'
+        return self.link(src, text=alt, title=title)
+
 
 
 def convert_github_markdown_to_asana_xml(text: str) -> str:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -52,20 +52,21 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return re.sub(URL_REGEX, urlreplace, text)
 
     def link(self, link, text=None, title=None):
-        is_asana_vanity_link = link.startswith("https://app.asana.com") and text is not None
+        is_asana_vanity_link = (
+            link.startswith("https://app.asana.com") and text is not None
+        )
         if text is None:
             text = link
 
         asana_tags = 'data-asana-dynamic="false" ' if is_asana_vanity_link else ""
-        s = '<a ' + asana_tags + 'href="' + self._safe_url(link) + '"'
+        s = "<a " + asana_tags + 'href="' + self._safe_url(link) + '"'
         if title:
             s += ' title="' + mistune.escape_html(title) + '"'
-        return s + '>' + (text or link) + '</a>'
+        return s + ">" + (text or link) + "</a>"
 
     # Asana's API can't handle img tags
     def image(self, src, alt="", title=None) -> str:
         return self.link(src, text=alt, title=title)
-
 
 
 def convert_github_markdown_to_asana_xml(text: str) -> str:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -52,16 +52,16 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return re.sub(URL_REGEX, urlreplace, text)
 
     def link(self, link, text=None, title=None):
-        is_asana_vanity_link = (
-            link.startswith("https://app.asana.com") and text is not None
-        )
+        # the parser may pass in `title`, but Asana's API does not allow the
+        # `title` attribute and is therefore ignored here.
+        # https://developers.asana.com/docs/rich-text
+
+        is_asana_vanity_link = link.startswith("https://app.asana.com") and text
         if text is None:
             text = link
 
         asana_tags = 'data-asana-dynamic="false" ' if is_asana_vanity_link else ""
         s = "<a " + asana_tags + 'href="' + self._safe_url(link) + '"'
-        if title:
-            s += ' title="' + mistune.escape_html(title) + '"'
         return s + ">" + (text or link) + "</a>"
 
     # Asana's API can't handle img tags

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -82,7 +82,9 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         md = 'hi [there](https://www.test.com "foo")'
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
-            xml, 'hi <a href="https://www.test.com" title="foo">there</a>\n'
+            # title should get ignored
+            xml,
+            'hi <a href="https://www.test.com">there</a>\n',
         )
 
     def test_converts_headings_to_bold(self):

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -55,6 +55,38 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
             ' href="www.test.com">still works</a>\n',
         )
 
+    def test_link_to_non_asana_url(self):
+        md = "hi [there](https://www.test.com)"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            'hi <a href="https://www.test.com">there</a>\n'
+        )
+
+    def test_link_to_asana_url_adds_data_asana_dynamic_false(self):
+        md = "hi [there](https://app.asana.com/0/1)"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            'hi <a data-asana-dynamic="false" href="https://app.asana.com/0/1">there</a>\n'
+        )
+
+    def test_link_to_asana_url_with_no_vanity_text_does_not_add_data_asana_dynamic(self):
+        md = "hi https://app.asana.com/0/1"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            'hi <a href="https://app.asana.com/0/1">https://app.asana.com/0/1</a>\n'
+        )
+
+    def test_link_with_title(self):
+        md = 'hi [there](https://www.test.com "foo")'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            xml,
+            'hi <a href="https://www.test.com" title="foo">there</a>\n'
+        )
+
     def test_converts_headings_to_bold(self):
         md = "## heading"
         xml = convert_github_markdown_to_asana_xml(md)

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -58,33 +58,31 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
     def test_link_to_non_asana_url(self):
         md = "hi [there](https://www.test.com)"
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(
-            xml,
-            'hi <a href="https://www.test.com">there</a>\n'
-        )
+        self.assertEqual(xml, 'hi <a href="https://www.test.com">there</a>\n')
 
     def test_link_to_asana_url_adds_data_asana_dynamic_false(self):
         md = "hi [there](https://app.asana.com/0/1)"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
-            'hi <a data-asana-dynamic="false" href="https://app.asana.com/0/1">there</a>\n'
+            'hi <a data-asana-dynamic="false" href="https://app.asana.com/0/1">there</a>\n',
         )
 
-    def test_link_to_asana_url_with_no_vanity_text_does_not_add_data_asana_dynamic(self):
+    def test_link_to_asana_url_with_no_vanity_text_does_not_add_data_asana_dynamic(
+        self,
+    ):
         md = "hi https://app.asana.com/0/1"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
-            'hi <a href="https://app.asana.com/0/1">https://app.asana.com/0/1</a>\n'
+            'hi <a href="https://app.asana.com/0/1">https://app.asana.com/0/1</a>\n',
         )
 
     def test_link_with_title(self):
         md = 'hi [there](https://www.test.com "foo")'
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
-            xml,
-            'hi <a href="https://www.test.com" title="foo">there</a>\n'
+            xml, 'hi <a href="https://www.test.com" title="foo">there</a>\n'
         )
 
     def test_converts_headings_to_bold(self):


### PR DESCRIPTION
See: https://app.asana.com/0/1198486630539940/1202909536189519/f / https://app.asana.com/0/780306770840675/1202908585602823/f

If someone references an Asana task with a vanity url text, Asana will try to evaluate to the object's title unless `data-asana-dynamic` is set to `false`


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203010140121164)