### PR TITLE
Don't allow people to approve their own PRs

### DIFF
--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -114,7 +114,8 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
         postmerge_comments = [
             comment
             for comment in pull_request.comments()
-            if comment.published_at() >= merged_at and comment.author_handle() != pull_request.author_handle()
+            if comment.published_at() >= merged_at
+            and comment.author_handle() != pull_request.author_handle()
             # TODO: consider using the lastEditedAt timestamp. A reviewer might comment: "noice!" prior to the PR being
             #       merged, then update their comment to "noice! LGTM!!!" after it had been merged.  This would however not
             #       suffice to cause the PR to be considered approved after merging.

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -114,7 +114,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
         postmerge_comments = [
             comment
             for comment in pull_request.comments()
-            if comment.published_at() >= merged_at
+            if comment.published_at() >= merged_at and comment.author_handle() != pull_request.author_handle()
             # TODO: consider using the lastEditedAt timestamp. A reviewer might comment: "noice!" prior to the PR being
             #       merged, then update their comment to "noice! LGTM!!!" after it had been merged.  This would however not
             #       suffice to cause the PR to be considered approved after merging.
@@ -128,7 +128,6 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews
         ]
-        # TODO: consider whether we should disallow the pr author to approve their own pr via a LGTM comment
         return bool(
             [
                 body_text

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -496,6 +496,32 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
         )
         self.assertEqual(True, task_fields["completed"])
 
+    def test_completed_is_false_if_pr_was_merged_and_changes_requested_and_commented_lgtm_on_the_pr_after_merge_by_author(
+        self,
+    ):
+        author = builder.user().build()
+        pull_request = build(
+            builder.pull_request()
+            .author(author)
+            .closed(True)
+            .merged(True)
+            .merged_at("2020-01-13T14:59:59Z")
+            .reviews(
+                [
+                    builder.review()
+                    .submitted_at("2020-01-13T14:59:57Z")
+                    .state(ReviewState.CHANGES_REQUESTED)
+                ]
+            )
+            .comments(
+                [builder.comment().author(author).published_at("2020-02-02T12:12:12Z").body("LGTM!")]
+            )
+        )
+        task_fields = src.asana.helpers.extract_task_fields_from_pull_request(
+            pull_request
+        )
+        self.assertEqual(False, task_fields["completed"])
+
     def test_completed_is_false_if_pr_was_merged_and_changes_requested_and_commented_lgtm_on_the_pr_before_merge(
         self,
     ):

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -514,7 +514,12 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
                 ]
             )
             .comments(
-                [builder.comment().author(author).published_at("2020-02-02T12:12:12Z").body("LGTM!")]
+                [
+                    builder.comment()
+                    .author(author)
+                    .published_at("2020-02-02T12:12:12Z")
+                    .body("LGTM!")
+                ]
             )
         )
         task_fields = src.asana.helpers.extract_task_fields_from_pull_request(

--- a/test/impl/builders/comment_builder.py
+++ b/test/impl/builders/comment_builder.py
@@ -11,7 +11,7 @@ class CommentBuilder(BuilderBaseClass):
         self.raw_comment = {
             "id": create_uuid(),
             "body": body,
-            "author": {"login": "somebody", "name": ""},
+            "author": {"login": UserBuilder.next_login(), "name": ""},
             "url": url,
         }
 

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -47,7 +47,7 @@ class PullRequestBuilder(BuilderBaseClass):
             "merged": False,
             "isDraft": False,
             "mergeable": MergeableState.MERGEABLE,
-            "author": {"login": "somebody", "name": ""},
+            "author": {"login": UserBuilder.next_login(), "name": ""},
             "repository": {
                 "id": create_uuid(),
                 "name": create_uuid(),

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -9,8 +9,8 @@ class UserBuilder(BuilderBaseClass):
 
     def __init__(self, login: str = None, name: str = ""):
         if login is None:
-            login = f"somebody_{self.LOGIN_COUNTER}"
-            self.LOGIN_COUNTER += 1
+            login = f"somebody_{UserBuilder.LOGIN_COUNTER}"
+            UserBuilder.LOGIN_COUNTER += 1
         self.raw_user = {"id": create_uuid(), "login": login, "name": name}
 
     def login(self, login: str):

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -9,7 +9,7 @@ class UserBuilder(BuilderBaseClass):
 
     def __init__(self, login: str = None, name: str = ""):
         if login is None:
-            login = "somebody_" + self.LOGIN_COUNTER
+            login = f"somebody_{self.LOGIN_COUNTER}"
             self.LOGIN_COUNTER += 1
         self.raw_user = {"id": create_uuid(), "login": login, "name": name}
 

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -9,9 +9,15 @@ class UserBuilder(BuilderBaseClass):
 
     def __init__(self, login: str = None, name: str = ""):
         if login is None:
-            login = f"somebody_{UserBuilder.LOGIN_COUNTER}"
-            UserBuilder.LOGIN_COUNTER += 1
+            login = UserBuilder.next_login()
         self.raw_user = {"id": create_uuid(), "login": login, "name": name}
+
+    @staticmethod
+    def next_login():
+        login = f"somebody_{UserBuilder.LOGIN_COUNTER}"
+        UserBuilder.LOGIN_COUNTER += 1
+        return login
+
 
     def login(self, login: str):
         self.raw_user["login"] = login

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -18,7 +18,6 @@ class UserBuilder(BuilderBaseClass):
         UserBuilder.LOGIN_COUNTER += 1
         return login
 
-
     def login(self, login: str):
         self.raw_user["login"] = login
         return self

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -5,7 +5,12 @@ from .builder_base_class import BuilderBaseClass
 
 
 class UserBuilder(BuilderBaseClass):
-    def __init__(self, login: str = "somebody", name: str = ""):
+    LOGIN_COUNTER = 0
+
+    def __init__(self, login: str = None, name: str = ""):
+        if login is None:
+            login = "somebody_" + self.LOGIN_COUNTER
+            self.LOGIN_COUNTER += 1
         self.raw_user = {"id": create_uuid(), "login": login, "name": name}
 
     def login(self, login: str):


### PR DESCRIPTION
Currently, you can approve your own PR with a post-merge comment of "LGTM" etc. This doesn't make much sense, so fix that logic!

See: https://app.asana.com/0/1149418478823393/950842749763706/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203018387208642)