### PR TITLE
Update automerge comment to be more accurate

### DIFF
--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -172,25 +172,28 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
         repo_name = pull_request.repository_name()
         pr_number = pull_request.number()
 
-        has_automerge_after_tests_and_approval = pull_request_has_label(pull_request, AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value)
-        has_automerge_after_approval = pull_request_has_label(pull_request, AutomergeLabel.AFTER_APPROVAL.value)
-
+        has_automerge_after_tests_and_approval = pull_request_has_label(
+            pull_request, AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value
+        )
+        has_automerge_after_approval = pull_request_has_label(
+            pull_request, AutomergeLabel.AFTER_APPROVAL.value
+        )
 
         # if a PR has an automerge label and doesn't contain a comment warning, we want to maybe add a warning comment
         # only add warning comment if it's set to auto-merge after approval and hasn't yet been approved to limit noise
 
         if (
-            (
-                has_automerge_after_tests_and_approval or has_automerge_after_approval
-            )
+            (has_automerge_after_tests_and_approval or has_automerge_after_approval)
             and not _pull_request_has_automerge_comment(pull_request)
             and not pull_request.is_approved()
         ):
 
-            automerge_comment = AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL if has_automerge_after_tests_and_approval else AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
-            github_client.add_pr_comment(
-                owner, repo_name, pr_number, automerge_comment
+            automerge_comment = (
+                AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
+                if has_automerge_after_tests_and_approval
+                else AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
             )
+            github_client.add_pr_comment(owner, repo_name, pr_number, automerge_comment)
 
 
 # returns True if the pull request was automerged, False if not
@@ -253,6 +256,9 @@ def _is_pull_request_ready_for_automerge(pull_request: PullRequest) -> bool:
 
 def _pull_request_has_automerge_comment(pull_request: PullRequest) -> bool:
     return any(
-        (comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL or comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL)
+        (
+            comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
+            or comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
+        )
         for comment in pull_request.comments()
     )

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -178,21 +178,21 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
         has_automerge_after_approval = pull_request_has_label(
             pull_request, AutomergeLabel.AFTER_APPROVAL.value
         )
+        automerge_comment = (
+            AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
+            if has_automerge_after_tests_and_approval
+            else AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
+        )
 
         # if a PR has an automerge label and doesn't contain a comment warning, we want to maybe add a warning comment
         # only add warning comment if it's set to auto-merge after approval and hasn't yet been approved to limit noise
 
         if (
             (has_automerge_after_tests_and_approval or has_automerge_after_approval)
-            and not _pull_request_has_automerge_comment(pull_request)
+            and not _pull_request_has_automerge_comment(pull_request, automerge_comment)
             and not pull_request.is_approved()
         ):
 
-            automerge_comment = (
-                AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
-                if has_automerge_after_tests_and_approval
-                else AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
-            )
             github_client.add_pr_comment(owner, repo_name, pr_number, automerge_comment)
 
 
@@ -254,11 +254,9 @@ def _is_pull_request_ready_for_automerge(pull_request: PullRequest) -> bool:
     return False
 
 
-def _pull_request_has_automerge_comment(pull_request: PullRequest) -> bool:
+def _pull_request_has_automerge_comment(
+    pull_request: PullRequest, automerge_comment: str
+) -> bool:
     return any(
-        (
-            comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
-            or comment.body() == AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL
-        )
-        for comment in pull_request.comments()
+        comment.body() == automerge_comment for comment in pull_request.comments()
     )

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -99,8 +99,14 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
         self, add_pr_comment_mock, edit_pr_title_mock
     ):
         for (label, automerge_comment) in [
-            (github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value, github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL),
-            (github_logic.AutomergeLabel.AFTER_APPROVAL.value, github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL),
+            (
+                github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value,
+                github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL,
+            ),
+            (
+                github_logic.AutomergeLabel.AFTER_APPROVAL.value,
+                github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL,
+            ),
         ]:
             pull_request = build(
                 builder.pull_request()
@@ -127,7 +133,9 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
                 [
                     builder.comment()
                     .author(builder.user("github_unknown_user_login"))
-                    .body(github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL)
+                    .body(
+                        github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL
+                    )
                 ]
             )
             .label(

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -98,9 +98,9 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
     def test_adds_warnings_if_label_and_no_warning_in_comments(
         self, add_pr_comment_mock, edit_pr_title_mock
     ):
-        for label in [
-            github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value,
-            github_logic.AutomergeLabel.AFTER_APPROVAL.value,
+        for (label, automerge_comment) in [
+            (github_logic.AutomergeLabel.AFTER_TESTS_AND_APPROVAL.value, github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL),
+            (github_logic.AutomergeLabel.AFTER_APPROVAL.value, github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_APPROVAL),
         ]:
             pull_request = build(
                 builder.pull_request()
@@ -114,7 +114,7 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
                 pull_request.repository_owner_handle(),
                 pull_request.repository_name(),
                 pull_request.number(),
-                github_logic.AUTOMERGE_COMMENT_WARNING,
+                automerge_comment,
             )
 
     @patch("src.github.logic.SGTM_FEATURE__AUTOMERGE_ENABLED", True)
@@ -127,7 +127,7 @@ class TestMaybeAddAutomergeWarningTitleAndComment(unittest.TestCase):
                 [
                     builder.comment()
                     .author(builder.user("github_unknown_user_login"))
-                    .body(github_logic.AUTOMERGE_COMMENT_WARNING)
+                    .body(github_logic.AUTOMERGE_COMMENT_WARNING_AFTER_TESTS_AND_APPROVAL)
                 ]
             )
             .label(


### PR DESCRIPTION
When automerge after _approval only_ label is selected, the comment was referencing automerge after tests as well. This PR introduces a new comment to more accurately reflect that automerge label, which does not mention tests!

(see: https://app.asana.com/0/780306770840675/1203239731436292/f)


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203315587152182)