### PR TITLE
Split server_side_encryption for s3 bucket into its own resource

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -343,12 +343,21 @@ terraform {
 
 resource "aws_s3_bucket" "api_key_bucket" {
   bucket = var.api_key_s3_bucket_name
-  server_side_encryption_configuration {
+
+  # See: https://github.com/hashicorp/terraform-provider-aws/issues/23106#issuecomment-1099401600
+  lifecycle {
+    ignore_changes = [
+      server_side_encryption_configuration
+    ]
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "api_key_bucket_server_side_encryption_configuration" {
+    bucket = aws_s3_bucket.api_key_bucket.bucket
     rule {
       apply_server_side_encryption_by_default {
         kms_master_key_id = aws_kms_key.api_encryption_key.arn
         sse_algorithm     = "aws:kms"
       }
     }
-  }
 }


### PR DESCRIPTION
Discussion about this [here](https://github.com/hashicorp/terraform-provider-aws/issues/23106) but tldr is that in later versions of the AWS provider, individual configurations on S3 buckets are split out into their own Terraform resources. This was backported to v3.75.2 (which is what we're currently using) to prep for the breaking change.

I already imported into Asana's remote state so this is a no-op


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203355580854612)