### PR TITLE
Remove commit status, just use statusCheckRollup

### DIFF
--- a/src/github/graphql/fragments/FullPullRequest.py
+++ b/src/github/graphql/fragments/FullPullRequest.py
@@ -68,9 +68,6 @@ fragment FullPullRequest on PullRequest {
   commits(last: 1) {
     nodes {
       commit {
-        status {
-          state
-        }
         statusCheckRollup {
           state
         }

--- a/src/github/models/commit.py
+++ b/src/github/models/commit.py
@@ -12,9 +12,7 @@ class Commit(object):
 
     # A commit's status can be None while the logic to start tests runs right after committing.
     def status(self) -> Optional[str]:
-        status = self._raw["commit"].get("status")
-        if status is None:
-            status = self._raw["commit"].get("statusCheckRollup")
+        status = self._raw["commit"].get("statusCheckRollup")
 
         if status is None:
             return None

--- a/test/github/models/test_commit.py
+++ b/test/github/models/test_commit.py
@@ -4,25 +4,15 @@ from src.github.models import Commit
 
 
 class TestCommit(BaseClass):
-    def test_status_success(self):
-        raw_commit = {"commit": {"status": {"state": Commit.BUILD_SUCCESSFUL}}}
+    def test_status_check_rollup_success(self):
+        raw_commit = {"commit": {"statusCheckRollup": {"state": Commit.BUILD_SUCCESSFUL}}}
         commit = Commit(raw_commit)
         self.assertEqual(commit.status(), Commit.BUILD_SUCCESSFUL)
 
-    def test_status_none(self):
-        raw_commit = {"commit": {"status": None}}
+    def test_status_check_rollup_none(self):
+        raw_commit = {"commit": {"statusCheckRollup": None}}
         commit = Commit(raw_commit)
         self.assertEqual(commit.status(), None)
-
-    def test_status_falls_back_to_status_rollup(self):
-        raw_commit = {
-            "commit": {
-                "status": None,
-                "statusCheckRollup": {"state": Commit.BUILD_PENDING},
-            }
-        }
-        commit = Commit(raw_commit)
-        self.assertEqual(commit.status(), Commit.BUILD_PENDING)
 
 
 if __name__ == "__main__":

--- a/test/github/models/test_commit.py
+++ b/test/github/models/test_commit.py
@@ -5,7 +5,9 @@ from src.github.models import Commit
 
 class TestCommit(BaseClass):
     def test_status_check_rollup_success(self):
-        raw_commit = {"commit": {"statusCheckRollup": {"state": Commit.BUILD_SUCCESSFUL}}}
+        raw_commit = {
+            "commit": {"statusCheckRollup": {"state": Commit.BUILD_SUCCESSFUL}}
+        }
         commit = Commit(raw_commit)
         self.assertEqual(commit.status(), Commit.BUILD_SUCCESSFUL)
 

--- a/test/impl/builders/commit_builder.py
+++ b/test/impl/builders/commit_builder.py
@@ -8,13 +8,13 @@ class CommitBuilder(BuilderBaseClass):
     def __init__(self, status=Commit.BUILD_PENDING):
         self.raw_commit = {
             "commit": {
-                "status": {"state": status},
+                "statusCheckRollup": {"state": status},
                 "node_id": create_uuid(),
             }
         }
 
     def status(self, status: str) -> Union["CommitBuilder", Commit]:
-        self.raw_commit["commit"]["status"]["state"] = status
+        self.raw_commit["commit"]["statusCheckRollup"]["state"] = status
         return self
 
     def build(self) -> Commit:

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -33,7 +33,7 @@ class PullRequestBuilder(BuilderBaseClass):
                 "nodes": [
                     {
                         "commit": {
-                            "status": {"state": Commit.BUILD_PENDING},
+                            "statusCheckRollup": {"state": Commit.BUILD_PENDING},
                             "node_id": create_uuid(),
                         }
                     }


### PR DESCRIPTION
Fixes: https://app.asana.com/0/1149418478823393/1203565858490862/f

This is happening because there are two types of "status". One is a "commit status" (status _classic_), the other is a check run. If we were _only_ relying on the status and falling back to statusCheckRollup, we were incorrectly assuming the PR was in a "success" state when certain types of checks runs (like we use for Testville) would be ignored in this logic.


[This blog post helped me understand the difference, and how we were mis-using status](https://dev.to/gr2m/github-api-how-to-retrieve-the-combined-pull-request-status-from-commit-statuses-check-runs-and-github-action-results-2cen)

Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203618452841244)