### PR TITLE
Update due date to today if PR is handed off to new assignee

### DIFF
--- a/src/asana/client.py
+++ b/src/asana/client.py
@@ -146,12 +146,12 @@ class AsanaClient(object):
         )
 
 
-
 def get_task(task_id: str) -> dict:
     """
     Gets an Asana Task given a task id
     """
     return AsanaClient.singleton().get_task(task_id)
+
 
 def create_task(project_id: str, due_date_str: str = None) -> str:
     """

--- a/src/asana/client.py
+++ b/src/asana/client.py
@@ -47,6 +47,13 @@ class AsanaClient(object):
             cls._singleton = AsanaClient()
         return cls._singleton
 
+    def get_task(self, task_id: str) -> dict:
+        """
+        Gets an Asana Task given a task id
+        """
+        validate_object_id(task_id, "AsanaClient.get_task requires a task_id")
+        return self.asana_api_client.tasks.find_by_id(task_id)
+
     def create_task(self, project_id: str, due_date_str: str = None) -> str:
         """
         Creates an Asana task in the specified project, returning the task_id
@@ -138,6 +145,13 @@ class AsanaClient(object):
             task_id, attachment_content, attachment_name, attachment_type
         )
 
+
+
+def get_task(task_id: str) -> dict:
+    """
+    Gets an Asana Task given a task id
+    """
+    return AsanaClient.singleton().get_task(task_id)
 
 def create_task(project_id: str, due_date_str: str = None) -> str:
     """

--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -45,10 +45,10 @@ def update_task(pull_request: PullRequest, task_id: str):
 
 def _new_due_on_or_none(task: dict, update_task_fields: dict) -> Optional[str]:
     due_on = None
-    default_due_on = asana_helpers.default_due_date_str()
+    today = datetime.now().strftime("%Y-%m-%d")
 
-    if task["due_on"] > default_due_on:
-        # don't update due dates that were potentially manually updated past the default
+    if task["due_on"] >= today:
+        # don't update due dates that aren't stale
         return None
     elif (task.get("assignee") or {}).get("gid") != update_task_fields.get("assignee"):
         # if the task is switching assignees, update the due date to today

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -51,6 +51,11 @@ def extract_task_fields_from_pull_request(pull_request: PullRequest) -> dict:
     }
 
 
+def today_str() -> str:
+    today = datetime.now()
+    return today.strftime("%Y-%m-%d")
+
+
 def default_due_date_str(reference_datetime: datetime = None) -> str:
     if reference_datetime is None:
         reference_datetime = datetime.now()

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -69,9 +69,13 @@ def upsert_review(pull_request: PullRequest, review: Review):
             " now."
         )
         asana_controller.upsert_github_review_to_task(review, task_id)
+        force_update_due_today = False
         if review.is_approval_or_changes_requested():
             assign_pull_request_to_author(pull_request)
-        asana_controller.update_task(pull_request, task_id)
+            force_update_due_today = True
+        asana_controller.update_task(
+            pull_request, task_id, force_update_due_today=force_update_due_today
+        )
 
 
 def assign_pull_request_to_author(pull_request: PullRequest):

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch, Mock, MagicMock, call
 from test.impl.builders import builder, build
+from datetime import datetime
 
 
 from test.impl.base_test_case_class import BaseClass
@@ -109,6 +110,24 @@ class TestUpsertGithubReviewToTask(BaseClass):
             [("123", self.ASANA_COMMENT_ID), ("456", self.ASANA_COMMENT_ID)]
         )
         add_comment.assert_not_called()
+
+class TestNewDueOnOrNone(BaseClass):
+    def test_new_assignee_due_on_change(self):
+        task = {"assignee": {"gid": "123"}, "due_on": "2010-01-01"}
+        update_task_fields = {"assignee": "321"}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), datetime.now().strftime("%Y-%m-%d"))
+
+    def test_new_assignee_due_on_in_the_future(self):
+        future_due_on = "3000-01-01"
+        task = {"assignee": {"gid": "123"}, "due_on": future_due_on}
+        update_task_fields = {"assignee": "321"}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), None)
+
+    def test_same_assignee(self):
+        assignee_gid = "123"
+        task = {"assignee": {"gid": assignee_gid}, "due_on": "2010-01-01"}
+        update_task_fields = {"assignee": assignee_gid}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), None)
 
 
 @patch("src.asana.client.complete_task")

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -111,11 +111,15 @@ class TestUpsertGithubReviewToTask(BaseClass):
         )
         add_comment.assert_not_called()
 
+
 class TestNewDueOnOrNone(BaseClass):
     def test_new_assignee_due_on_change(self):
         task = {"assignee": {"gid": "123"}, "due_on": "2010-01-01"}
         update_task_fields = {"assignee": "321"}
-        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), datetime.now().strftime("%Y-%m-%d"))
+        self.assertEqual(
+            controller._new_due_on_or_none(task, update_task_fields),
+            datetime.now().strftime("%Y-%m-%d"),
+        )
 
     def test_new_assignee_due_on_in_the_future(self):
         future_due_on = "3000-01-01"

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -121,6 +121,12 @@ class TestNewDueOnOrNone(BaseClass):
             datetime.now().strftime("%Y-%m-%d"),
         )
 
+    def test_new_assignee_due_on_today(self):
+        due_on = datetime.now().strftime("%Y-%m-%d")
+        task = {"assignee": {"gid": "123"}, "due_on": due_on}
+        update_task_fields = {"assignee": "321"}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), None)
+
     def test_new_assignee_due_on_in_the_future(self):
         future_due_on = "3000-01-01"
         task = {"assignee": {"gid": "123"}, "due_on": future_due_on}


### PR DESCRIPTION
When a PR changes hands, it's because of an approval, request changes, or ready for re-review. Because SGTM currently only sets the due date _once_, for any back-and-forth handoff, the due dates can get overdue quickly. This PR introduces logic to set due date to _today_ when a PR changes assignees (unless SGTM thinks a collaborator has manually changed the due date to later intentionally)

See: https://app.asana.com/0/1149418478823393/1203831261518511/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1203877928337987)