### PR TITLE
Add follow-up review feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ v-env/
 
 # VSCode
 .vscode
+
+# Vim
+*.swp

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You'll need to create two Asana projects: one that will store the mapping of Git
      ```
       >>> To setup a new project
       python3 scripts/setup_sgtm_tasks_project.py  -p "<PAT>" create -n "<PROJECT NAME>" -t "<TEAM ID>"
-           
+
       >>> To update an existing project with the suggested custom fields
       python3 scripts/setup_sgtm_tasks_project.py  -p "<PAT>" update -e "<EXISTING PROJECT ID>"
       ```
@@ -124,6 +124,13 @@ Asana tasks:
 * Create a label of `complete tasks on merge` in your repository
 
 *Note*: If the SGTM user in your Asana domain doesn't have access to a linked task, it won't be able to merge it. You can add the SGTM user as a collaborator on a task to give it the ability to auto-complete the task.
+
+### Select users for follow-up review
+SGTM can avoid closing tasks if the approvals come from certain Github users.  This can be useful if you have specific Github users that you would like to be able to approve PRs in order to unblock merging, but that you want a second set of eyes on.
+For example, you may have a bot that automatically approves certain auto-generated PRs to speed up some workflow, but you still want a human to review those changes afterwards.
+
+**How to configure**:
+* Set an env variable of `TF_VAR_sgtm_feature__followup_review_github_users` to contain a comma-separated list of Github user ids that should have follow-up review
 
 ## Installing a Virtual Environment for Python
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ SGTM can avoid closing tasks if the approvals come from certain Github users.  T
 For example, you may have a bot that automatically approves certain auto-generated PRs to speed up some workflow, but you still want a human to review those changes afterwards.
 
 **How to configure**:
-* Set an env variable of `TF_VAR_sgtm_feature__followup_review_github_users` to contain a comma-separated list of Github user ids that should have follow-up review
+* Set an env variable of `TF_VAR_sgtm_feature__followup_review_github_users` to contain a comma-separated list of Github usernames that should have follow-up review
 
 ## Installing a Virtual Environment for Python
 

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -412,8 +412,19 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
         return StatusReason(False, "the pull request is open.")
     elif not pull_request.merged():
         return StatusReason(True, "the pull request was closed without merging code.")
-    elif github_logic.pull_request_approved_before_merging(pull_request):
+
+    approved_before_merge = github_logic.pull_request_approved_before_merging(
+        pull_request
+    )
+    if approved_before_merge == github_logic.ApprovedBeforeMergeStatus.APPROVED:
         return StatusReason(True, "the pull request was approved before merging.")
+    elif approved_before_merge == github_logic.ApprovedBeforeMergeStatus.NEEDS_FOLLOWUP:
+        return StatusReason(
+            False,
+            "the pull request was approved before merging by a Github user that "
+            + "requires follow-up review.  The Reviewer can close this task by "
+            + 'commenting "LGTM" on the Pull Request.',
+        )
     elif github_logic.pull_request_approved_after_merging(pull_request):
         return StatusReason(True, "the pull request was approved after merging.")
     else:

--- a/src/config.py
+++ b/src/config.py
@@ -35,5 +35,7 @@ SGTM_FEATURE__AUTOMERGE_ENABLED = is_feature_flag_enabled(
 )
 SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
     int(github_id)
-    for github_id in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS").split(",")
+    for github_id in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", "").split(
+        ","
+    )
 }

--- a/src/config.py
+++ b/src/config.py
@@ -35,8 +35,8 @@ SGTM_FEATURE__AUTOMERGE_ENABLED = is_feature_flag_enabled(
 )
 SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
     github_username
-    for github_username in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", "").split(
-        ","
-    )
+    for github_username in os.getenv(
+        "SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", ""
+    ).split(",")
     if github_username
 }

--- a/src/config.py
+++ b/src/config.py
@@ -34,9 +34,9 @@ SGTM_FEATURE__AUTOMERGE_ENABLED = is_feature_flag_enabled(
     "SGTM_FEATURE__AUTOMERGE_ENABLED"
 )
 SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
-    int(github_id)
-    for github_id in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", "").split(
+    github_username
+    for github_username in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", "").split(
         ","
     )
-    if github_id
+    if github_username
 }

--- a/src/config.py
+++ b/src/config.py
@@ -38,4 +38,5 @@ SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
     for github_id in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", "").split(
         ","
     )
+    if github_id
 }

--- a/src/config.py
+++ b/src/config.py
@@ -33,3 +33,7 @@ SGTM_FEATURE__AUTOCOMPLETE_ENABLED = is_feature_flag_enabled(
 SGTM_FEATURE__AUTOMERGE_ENABLED = is_feature_flag_enabled(
     "SGTM_FEATURE__AUTOMERGE_ENABLED"
 )
+SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
+    int(github_id)
+    for github_id in os.getenv("SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS").split(",")
+}

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -78,7 +78,7 @@ def upsert_review(pull_request: PullRequest, review: Review):
             # review, we should leave the PR assignee as is so they can do the
             # follow-up.  Otherwise, reassign to the author so they can take
             # action on the PR.
-            if review.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
+            if review.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
                 assign_pull_request_to_author(pull_request)
                 force_update_due_today = True
         asana_controller.update_task(

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -78,7 +78,10 @@ def upsert_review(pull_request: PullRequest, review: Review):
             # review, we should leave the PR assignee as is so they can do the
             # follow-up.  Otherwise, reassign to the author so they can take
             # action on the PR.
-            if review.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
+            if (
+                review.author().login()
+                not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            ):
                 assign_pull_request_to_author(pull_request)
                 force_update_due_today = True
         asana_controller.update_task(

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -1,11 +1,15 @@
 import re
 from typing import List
 from src.logger import logger
+
 from . import client as github_client
-from src.github.models import PullRequest, MergeableState
+from src.github.models import PullRequest, MergeableState, Review
 from enum import Enum, unique
 from src.github.helpers import pull_request_has_label
-from src.config import SGTM_FEATURE__AUTOMERGE_ENABLED
+from src.config import (
+    SGTM_FEATURE__AUTOMERGE_ENABLED,
+    SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS,
+)
 
 GITHUB_MENTION_REGEX = "\B@([a-zA-Z0-9_\-]+)"
 GITHUB_ATTACHMENT_REGEX = "!\[(.*?)\]\((.+?(\.png|\.jpg|\.jpeg|\.gif))"
@@ -29,6 +33,13 @@ class AutomergeLabel(Enum):
     AFTER_TESTS = "merge after tests"
     AFTER_APPROVAL = "merge after approval"
     IMMEDIATELY = "merge immediately"
+
+
+@unique
+class ApprovedBeforeMergeStatus(Enum):
+    NO = 0
+    NEEDS_FOLLOWUP = 1
+    APPROVED = 2
 
 
 def inject_asana_task_into_pull_request_body(body: str, task_url: str) -> str:
@@ -69,23 +80,53 @@ def _pull_request_commenters(pull_request: PullRequest) -> List[str]:
     return sorted(comment.author_handle() for comment in pull_request.comments())
 
 
-def pull_request_approved_before_merging(pull_request: PullRequest) -> bool:
+def pull_request_approved_before_merging(
+    pull_request: PullRequest,
+) -> ApprovedBeforeMergeStatus:
     """
     The pull request has been approved if the last review (approval/changes
-    requested) before merging was an approval
+    requested) before merging was an approval, ignoring reviews from users that
+    are marked as needing follow-up review.
     """
+    assert pull_request.merged(), "Checked for pre-merge approval on a non-merged PR"
     merged_at = pull_request.merged_at()
-    if merged_at is not None:
-        premerge_reviews = [
+    if merged_at is None:
+        # The PR was merged but we don't know when.  Assume it was approved after.
+        return ApprovedBeforeMergeStatus.NO
+
+    premerge_reviews = sorted(
+        (
             review
             for review in pull_request.reviews()
             if review.is_approval_or_changes_requested()
             and review.submitted_at() < merged_at
+        ),
+        key=lambda r: r.submitted_at(),
+    )
+
+    if len(premerge_reviews) == 0:
+        # We didn't find any reviews
+        return ApprovedBeforeMergeStatus.NO
+
+    latest_review = premerge_reviews[-1]
+    if not latest_review.is_approval():
+        return ApprovedBeforeMergeStatus.NO
+
+    # We know the last review was an approval, but we want to figure out
+    # whether it still needs follow-up review.
+    if latest_review.author().id() in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
+        # The last review needs follow-up - check if there was a review just
+        # before that which doesn't need follow-up.
+        no_followup_reviews = [
+            r
+            for r in premerge_reviews
+            if r.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
-        if premerge_reviews:
-            latest_review = sorted(premerge_reviews, key=lambda r: r.submitted_at())[-1]
-            return latest_review.is_approval()
-    return False
+        if len(no_followup_reviews) == 0 or not no_followup_reviews[-1].is_approval():
+            # There were no approvals before this that didn't need follow-up review.
+            return ApprovedBeforeMergeStatus.NEEDS_FOLLOWUP
+
+    return ApprovedBeforeMergeStatus.APPROVED
 
 
 def _is_approval_comment_body(body: str) -> bool:
@@ -110,6 +151,9 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
     a marker text, such as "LGTM" or "looks good to me".
 
     This method handles this part of the logic.
+
+    NOTE: We ignore actions from users who are marked as needing follow-up
+    review, since their input isn't useful after a PR has been merged.
     """
     merged_at = pull_request.merged_at()
     if merged_at is not None:
@@ -122,6 +166,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             for comment in pull_request.comments()
             if comment.published_at() >= merged_at
             and comment.author_handle() != pull_request.author_handle()
+            and comment.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
             # TODO: consider using the lastEditedAt timestamp. A reviewer might comment: "noice!" prior to the PR being
             #       merged, then update their comment to "noice! LGTM!!!" after it had been merged.  This would however not
             #       suffice to cause the PR to be considered approved after merging.
@@ -131,6 +176,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             review
             for review in pull_request.reviews()
             if review.submitted_at() >= merged_at
+            and review.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -166,7 +166,8 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             for comment in pull_request.comments()
             if comment.published_at() >= merged_at
             and comment.author_handle() != pull_request.author_handle()
-            and comment.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            and comment.author().login()
+            not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
             # TODO: consider using the lastEditedAt timestamp. A reviewer might comment: "noice!" prior to the PR being
             #       merged, then update their comment to "noice! LGTM!!!" after it had been merged.  This would however not
             #       suffice to cause the PR to be considered approved after merging.
@@ -176,7 +177,8 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             review
             for review in pull_request.reviews()
             if review.submitted_at() >= merged_at
-            and review.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            and review.author().login()
+            not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -114,13 +114,13 @@ def pull_request_approved_before_merging(
 
     # We know the last review was an approval, but we want to figure out
     # whether it still needs follow-up review.
-    if latest_review.author().id() in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
+    if latest_review.author().login() in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS:
         # The last review needs follow-up - check if there was a review just
         # before that which doesn't need follow-up.
         no_followup_reviews = [
             r
             for r in premerge_reviews
-            if r.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            if r.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
         if len(no_followup_reviews) == 0 or not no_followup_reviews[-1].is_approval():
             # There were no approvals before this that didn't need follow-up review.
@@ -166,7 +166,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             for comment in pull_request.comments()
             if comment.published_at() >= merged_at
             and comment.author_handle() != pull_request.author_handle()
-            and comment.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            and comment.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
             # TODO: consider using the lastEditedAt timestamp. A reviewer might comment: "noice!" prior to the PR being
             #       merged, then update their comment to "noice! LGTM!!!" after it had been merged.  This would however not
             #       suffice to cause the PR to be considered approved after merging.
@@ -176,7 +176,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             review
             for review in pull_request.reviews()
             if review.submitted_at() >= merged_at
-            and review.author().id() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
+            and review.author().login() not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -180,6 +180,7 @@ resource "aws_lambda_function" "sgtm" {
       API_KEYS_S3_KEY                    = var.api_key_s3_object,
       SGTM_FEATURE__AUTOMERGE_ENABLED    = var.sgtm_feature__automerge_enabled,
       SGTM_FEATURE__AUTOCOMPLETE_ENABLED = var.sgtm_feature__autocomplete_enabled,
+      SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = var.sgtm_feature__followup_review_github_users
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,6 +62,6 @@ variable "sgtm_feature__autocomplete_enabled" {
 
 variable "sgtm_feature__followup_review_github_users" {
   type        = string
-  description = "A comma-separated list of Github user ids that require follow-up review after merge"
+  description = "A comma-separated list of Github usernames that require follow-up review after merge"
   default     = ""
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -59,3 +59,9 @@ variable "sgtm_feature__autocomplete_enabled" {
   description = "'true' if behavior to autocomplete linked tasks with Github labels is enabled"
   default     = "false"
 }
+
+variable "sgtm_feature__followup_review_github_users" {
+  type        = string
+  description = "A comma-separated list of Github user ids that require follow-up review after merge"
+  default     = ""
+}

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -455,7 +455,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
 
     @patch(
         "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
-        {followup_bot.id()},
+        {followup_bot.login()},
     )
     def test_completed_is_false_if_pr_is_closed_and_was_approved_by_followup_user(self):
         pull_request = build(
@@ -481,7 +481,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
 
     @patch(
         "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
-        {followup_bot.id()},
+        {followup_bot.login()},
     )
     def test_completed_is_true_if_pr_is_closed_and_was_approved_by_human_and_followup_user(
         self,

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -454,7 +454,8 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
         self.assertEqual(False, task_fields["completed"])
 
     @patch(
-        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot.id()]
+        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
+        [followup_bot.id()],
     )
     def test_completed_is_false_if_pr_is_closed_and_was_approved_by_followup_user(self):
         pull_request = build(
@@ -479,7 +480,8 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
         self.assertEqual(False, task_fields["completed"])
 
     @patch(
-        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot.id()]
+        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
+        [followup_bot.id()],
     )
     def test_completed_is_true_if_pr_is_closed_and_was_approved_by_human_and_followup_user(
         self,

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -430,7 +430,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
             builder.pull_request()
             .closed(True)
             .merged(True)
-            .merged("2020-01-13T14:59:59Z")
+            .merged_at("2020-01-13T14:59:59Z")
             .reviews(
                 [
                     (

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from src.github.models import Commit
 from src.github.logic import ApprovedBeforeMergeStatus
 
-followup_bot = builder.user("follow_up")
+followup_bot = builder.user("follow_up").build()
 
 
 @dataclass
@@ -454,14 +454,14 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
         self.assertEqual(False, task_fields["completed"])
 
     @patch(
-        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot]
+        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot.id()]
     )
     def test_completed_is_false_if_pr_is_closed_and_was_approved_by_followup_user(self):
         pull_request = build(
             builder.pull_request()
             .closed(True)
             .merged(True)
-            .merged("2020-01-13T14:59:59Z")
+            .merged_at("2020-01-13T14:59:59Z")
             .reviews(
                 [
                     (
@@ -479,7 +479,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
         self.assertEqual(False, task_fields["completed"])
 
     @patch(
-        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot]
+        "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS", [followup_bot.id()]
     )
     def test_completed_is_true_if_pr_is_closed_and_was_approved_by_human_and_followup_user(
         self,

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -455,7 +455,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
 
     @patch(
         "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
-        [followup_bot.id()],
+        {followup_bot.id()},
     )
     def test_completed_is_false_if_pr_is_closed_and_was_approved_by_followup_user(self):
         pull_request = build(
@@ -481,7 +481,7 @@ class TestExtractsCompletedStatusFromPullRequest(BaseClass):
 
     @patch(
         "src.github.logic.SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS",
-        [followup_bot.id()],
+        {followup_bot.id()},
     )
     def test_completed_is_true_if_pr_is_closed_and_was_approved_by_human_and_followup_user(
         self,

--- a/test/github/test_is_pull_request_ready_for_automerge.py
+++ b/test/github/test_is_pull_request_ready_for_automerge.py
@@ -467,12 +467,15 @@ class GithubLogicTest(unittest.TestCase):
                     builder.review()
                     .submitted_at(submitted_at)
                     .state(ReviewState.APPROVED)
+                    .author(builder.user("human"))
                 ]
             )
             .merged_at(merged_at)
+            .merged(True)
         )
-        self.assertFalse(
-            github_logic.pull_request_approved_before_merging(pull_request)
+        self.assertEqual(
+            github_logic.pull_request_approved_before_merging(pull_request),
+            github_logic.ApprovedBeforeMergeStatus.NO,
         )
 
     def test_pull_request_approved_before_merging_review_approved_before_merge(self):
@@ -486,11 +489,16 @@ class GithubLogicTest(unittest.TestCase):
                     builder.review()
                     .submitted_at(submitted_at)
                     .state(ReviewState.APPROVED)
+                    .author(builder.user("human"))
                 ]
             )
             .merged_at(merged_at)
+            .merged(True)
         )
-        self.assertTrue(github_logic.pull_request_approved_before_merging(pull_request))
+        self.assertEqual(
+            github_logic.pull_request_approved_before_merging(pull_request),
+            github_logic.ApprovedBeforeMergeStatus.APPROVED,
+        )
 
     def test_pull_request_approved_before_merging_review_requested_changes_before_merge(
         self,
@@ -505,22 +513,30 @@ class GithubLogicTest(unittest.TestCase):
                     builder.review()
                     .submitted_at(submitted_at)
                     .state(ReviewState.CHANGES_REQUESTED)
+                    .author(builder.user("human"))
                 ]
             )
             .merged_at(merged_at)
+            .merged(True)
         )
-        self.assertFalse(
-            github_logic.pull_request_approved_before_merging(pull_request)
+        self.assertEqual(
+            github_logic.pull_request_approved_before_merging(pull_request),
+            github_logic.ApprovedBeforeMergeStatus.NO,
         )
 
     def test_pull_request_approved_before_merging_no_reviews(self):
-        pull_request = builder.pull_request().merged_at(datetime.now()).build()
-        self.assertFalse(
-            github_logic.pull_request_approved_before_merging(pull_request)
+        pull_request = (
+            builder.pull_request().merged_at(datetime.now()).merged(True).build()
+        )
+        self.assertEqual(
+            github_logic.pull_request_approved_before_merging(pull_request),
+            github_logic.ApprovedBeforeMergeStatus.NO,
         )
 
     def test_pull_request_approved_after_merging_no_reviews_or_comments(self):
-        pull_request = builder.pull_request().merged_at(datetime.now()).build()
+        pull_request = (
+            builder.pull_request().merged_at(datetime.now()).merged(True).build()
+        )
         self.assertFalse(github_logic.pull_request_approved_after_merging(pull_request))
 
     def test_pull_request_approved_after_merging_reviews_and_comments_no_approvals(
@@ -534,9 +550,20 @@ class GithubLogicTest(unittest.TestCase):
         pull_request = build(
             builder.pull_request()
             .merged_at(datetime.now())
-            .reviews([builder.review("This looks OK").submitted_at(reviewed_at)])
+            .merged(True)
+            .reviews(
+                [
+                    builder.review("This looks OK")
+                    .submitted_at(reviewed_at)
+                    .author(builder.user("human"))
+                ]
+            )
             .comments(
-                [builder.comment("v cool use of emojis").published_at(commented_at)]
+                [
+                    builder.comment("v cool use of emojis")
+                    .published_at(commented_at)
+                    .author(builder.user("human"))
+                ]
             )
         )
         self.assertFalse(github_logic.pull_request_approved_after_merging(pull_request))
@@ -548,8 +575,21 @@ class GithubLogicTest(unittest.TestCase):
         pull_request = build(
             builder.pull_request()
             .merged_at(datetime.now())
-            .reviews([builder.review("This looks OK").submitted_at(reviewed_at)])
-            .comments([builder.comment("SGTM!").published_at(commented_at)])
+            .merged(True)
+            .reviews(
+                [
+                    builder.review("This looks OK")
+                    .submitted_at(reviewed_at)
+                    .author(builder.user("human"))
+                ]
+            )
+            .comments(
+                [
+                    builder.comment("SGTM!")
+                    .published_at(commented_at)
+                    .author(builder.user("human"))
+                ]
+            )
         )
         self.assertTrue(github_logic.pull_request_approved_after_merging(pull_request))
 
@@ -560,11 +600,20 @@ class GithubLogicTest(unittest.TestCase):
         pull_request = build(
             builder.pull_request()
             .merged_at(datetime.now())
+            .merged(True)
             .reviews(
-                [builder.review("This looks great! :+1:").submitted_at(reviewed_at)]
+                [
+                    builder.review("This looks great! :+1:")
+                    .submitted_at(reviewed_at)
+                    .author(builder.user("human"))
+                ]
             )
             .comments(
-                [builder.comment("v cool use of emojis").published_at(commented_at)]
+                [
+                    builder.comment("v cool use of emojis")
+                    .published_at(commented_at)
+                    .author(builder.user("human"))
+                ]
             )
         )
         self.assertTrue(github_logic.pull_request_approved_after_merging(pull_request))


### PR DESCRIPTION
This makes it possible to specify a list of Github users that can approve PRs but have them not count as reviewed.

This is required to support the Asana-internal `PR Velocity Bot`, but may be a useful feature for other users.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204140428956027)