### PR TITLE
Fix follow-up reviews not being closed after `LGTM` comment

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -418,6 +418,8 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
     )
     if approved_before_merge == github_logic.ApprovedBeforeMergeStatus.APPROVED:
         return StatusReason(True, "the pull request was approved before merging.")
+    elif github_logic.pull_request_approved_after_merging(pull_request):
+        return StatusReason(True, "the pull request was approved after merging.")
     elif approved_before_merge == github_logic.ApprovedBeforeMergeStatus.NEEDS_FOLLOWUP:
         return StatusReason(
             False,
@@ -425,8 +427,6 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
             + "requires follow-up review.  The Reviewer can close this task by "
             + 'commenting "LGTM" on the Pull Request.',
         )
-    elif github_logic.pull_request_approved_after_merging(pull_request):
-        return StatusReason(True, "the pull request was approved after merging.")
     else:
         return StatusReason(
             False,

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -284,6 +284,34 @@ class TestExtractsMiscellaneousFieldsFromPullRequest(BaseClass):
 
     @patch("src.github.logic.pull_request_approved_before_merging")
     @patch("src.github.logic.pull_request_approved_after_merging")
+    def test_html_body_status_closed_needs_followup_approved_after(
+        self, approved_after_merging, approved_before_merging
+    ):
+        approved_before_merging.return_value = ApprovedBeforeMergeStatus.NEEDS_FOLLOWUP
+        approved_after_merging.return_value = True
+        pull_request = build(
+            builder.pull_request()
+            .author(builder.user("github_test_user_login"))
+            .url("https://foo.bar/baz")
+            .body("BODY")
+            .closed(True)
+            .merged(True)
+        )
+        task_fields = src.asana.helpers.extract_task_fields_from_pull_request(
+            pull_request
+        )
+        actual = task_fields["html_notes"]
+        expected_strings = [
+            "<body>",
+            "complete",
+            "the pull request was approved after merging.",
+            "BODY",
+            "</body>",
+        ]
+        self.assertContainsStrings(actual, expected_strings)
+
+    @patch("src.github.logic.pull_request_approved_before_merging")
+    @patch("src.github.logic.pull_request_approved_after_merging")
     def test_html_body_status_closed_approved_after(
         self, approved_after_merging, approved_before_merging
     ):


### PR DESCRIPTION
We short-circuited too soon and never looked for whether the PR had been post-merge approved after being approved by a follow-up user.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204171313719534)