### PR TITLE
Handle relative URLs

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -62,16 +62,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
         safe_url = self._safe_url(link)
         if self._is_valid_url(safe_url):
-            return (
-                "<a "
-                + asana_tags
-                + 'href="'
-                + safe_url
-                + '"'
-                + ">"
-                + (text or safe_url)
-                + "</a>"
-            )
+            return f'<a {asana_tags}href="{safe_url}">{text or safe_url}</a>'
         else:
             return escape(text or safe_url, quote=False)
 

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -62,14 +62,22 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
         safe_url = self._safe_url(link)
         if self._is_valid_url(safe_url):
-            return "<a " + asana_tags + 'href="' + safe_url + '"' + ">" + (text or safe_url) + "</a>"
+            return (
+                "<a "
+                + asana_tags
+                + 'href="'
+                + safe_url
+                + '"'
+                + ">"
+                + (text or safe_url)
+                + "</a>"
+            )
         else:
             return escape(text or safe_url, quote=False)
 
     # Asana's API can't handle img tags
     def image(self, src, alt="", title=None) -> str:
         return self.link(src, text=alt, title=title)
-
 
     def _is_valid_url(self, url: str) -> bool:
         try:

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -88,15 +88,13 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         )
 
     def test_link_to_relative_url(self):
-        md = 'check out the [docs](README.md)'
+        md = "check out the [docs](README.md)"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             # title should get ignored
             xml,
-            'check out the docs\n',
+            "check out the docs\n",
         )
-
-
 
     def test_converts_headings_to_bold(self):
         md = "## heading"

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -91,7 +91,6 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         md = "check out the [docs](README.md)"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
-            # title should get ignored
             xml,
             "check out the docs\n",
         )

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -6,12 +6,12 @@ from src.markdown_parser import convert_github_markdown_to_asana_xml
 
 class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
     def test_basic_markdown(self):
-        md = """~~strike~~ **bold** _italic_ `code` [link](asana.com)"""
+        md = """~~strike~~ **bold** _italic_ `code` [link](https://www.asana.com)"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
             "<s>strike</s> <strong>bold</strong> <em>italic</em> <code>code</code> <a"
-            ' href="asana.com">link</a>\n',
+            ' href="https://www.asana.com">link</a>\n',
         )
 
     def test_ul_tag(self):
@@ -47,12 +47,12 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         self.assertEqual(xml, md)  # unchanged
 
     def test_auto_linking(self):
-        md = "https://asana.com/ [still works](www.test.com)"
+        md = "https://asana.com/ [still works](https://www.test.com)"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
             '<a href="https://asana.com/">https://asana.com/</a> <a'
-            ' href="www.test.com">still works</a>\n',
+            ' href="https://www.test.com">still works</a>\n',
         )
 
     def test_link_to_non_asana_url(self):
@@ -86,6 +86,17 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
             xml,
             'hi <a href="https://www.test.com">there</a>\n',
         )
+
+    def test_link_to_relative_url(self):
+        md = 'check out the [docs](README.md)'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            # title should get ignored
+            xml,
+            'check out the docs\n',
+        )
+
+
 
     def test_converts_headings_to_bold(self):
         md = "## heading"


### PR DESCRIPTION
Asana API doesn't handle <a> hrefs that point to a URL without a scheme, so any "link" without a scheme/protocol such as:

* asana.com
* www.asana.com
* /reference/to/relative/file.md

Will be ignored and rendered as text


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204374742220051)