### PR TITLE
Add followers incrementally, allowing people to remove themselves from an SGTM task

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 from . import client as asana_client
 from . import helpers as asana_helpers
 from . import logic as asana_logic
@@ -20,21 +20,13 @@ def create_task(repository_id: str) -> Optional[str]:
 
 
 def update_task(
-    pull_request: PullRequest, task_id: str, force_update_due_today: bool = False
+        pull_request: PullRequest, task_id: str, followers: List[str], force_update_due_today: bool = False
 ):
     task_url = asana_helpers.task_url_from_task_id(task_id)
     pr_url = pull_request.url()
     logger.info(f"Updating task {task_url} for pull request {pr_url}")
 
-    fields = asana_helpers.extract_task_fields_from_pull_request(pull_request)
-
-    # TODO: Should extract_task_fields_from_pull_request be broken into two
-    # methods, one for fields and one for followers?
-    update_task_fields = {
-        k: v
-        for k, v in fields.items()
-        if k in ("assignee", "name", "html_notes", "completed", "custom_fields")
-    }
+    update_task_fields = asana_helpers.extract_task_fields_from_pull_request(pull_request)
     task = asana_client.get_task(task_id)
     new_due_on = (
         asana_helpers.today_str()
@@ -44,7 +36,7 @@ def update_task(
     if new_due_on is not None:
         update_task_fields["due_on"] = new_due_on
     asana_client.update_task(task_id, update_task_fields)
-    asana_client.add_followers(task_id, fields["followers"])
+    asana_client.add_followers(task_id, followers)
     maybe_complete_tasks_on_merge(pull_request)
 
 

--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -20,13 +20,18 @@ def create_task(repository_id: str) -> Optional[str]:
 
 
 def update_task(
-        pull_request: PullRequest, task_id: str, followers: List[str], force_update_due_today: bool = False
+    pull_request: PullRequest,
+    task_id: str,
+    followers: List[str],
+    force_update_due_today: bool = False,
 ):
     task_url = asana_helpers.task_url_from_task_id(task_id)
     pr_url = pull_request.url()
     logger.info(f"Updating task {task_url} for pull request {pr_url}")
 
-    update_task_fields = asana_helpers.extract_task_fields_from_pull_request(pull_request)
+    update_task_fields = asana_helpers.extract_task_fields_from_pull_request(
+        pull_request
+    )
     task = asana_client.get_task(task_id)
     new_due_on = (
         asana_helpers.today_str()

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -435,8 +435,24 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
             " Request.",
         )
 
+def task_followers_from_comment(comment: Comment) -> List[str]:
+    return _task_followers_from_gh_handles(github_logic.comment_participants_and_mentions(comment))
 
-def _task_followers_from_pull_request(pull_request: PullRequest):
+def task_followers_from_review(review: Review) -> List[str]:
+    return _task_followers_from_gh_handles(github_logic.review_participants_and_mentions(review))
+
+def task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
+    return _task_followers_from_gh_handles(github_logic.pull_request_participants(pull_request))
+
+def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
+    return [
+        _asana_user_id_from_github_handle(gh_handle)
+        for gh_handle in gh_handles
+        if _asana_user_id_from_github_handle(gh_handle) is not None
+    ]
+
+
+def _task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
     return [
         _asana_user_id_from_github_handle(gh_handle)
         for gh_handle in github_logic.all_pull_request_participants(pull_request)

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -470,7 +470,6 @@ def _task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
     ]
 
 
-
 def _wrap_in_tag(
     tag_name: str, attrs: Optional[Dict[str, str]] = None
 ) -> Callable[[str], str]:

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -46,7 +46,6 @@ def extract_task_fields_from_pull_request(pull_request: PullRequest) -> dict:
         "name": _task_name_from_pull_request(pull_request),
         "html_notes": _task_description_from_pull_request(pull_request),
         "completed": _task_completion_from_pull_request(pull_request).is_complete,
-        "followers": _task_followers_from_pull_request(pull_request),
         "custom_fields": _custom_fields_from_pull_request(pull_request),
     }
 
@@ -458,14 +457,6 @@ def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
     return [
         asana_user_id
         for gh_handle in gh_handles
-        if (asana_user_id := _asana_user_id_from_github_handle(gh_handle)) is not None
-    ]
-
-
-def _task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
-    return [
-        asana_user_id
-        for gh_handle in github_logic.all_pull_request_participants(pull_request)
         if (asana_user_id := _asana_user_id_from_github_handle(gh_handle)) is not None
     ]
 

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -456,18 +456,19 @@ def task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
 
 def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
     return [
-        _asana_user_id_from_github_handle(gh_handle)
+        asana_user_id
         for gh_handle in gh_handles
-        if _asana_user_id_from_github_handle(gh_handle) is not None
+        if (asana_user_id := _asana_user_id_from_github_handle(gh_handle)) is not None
     ]
 
 
 def _task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
     return [
-        _asana_user_id_from_github_handle(gh_handle)
+        asana_user_id
         for gh_handle in github_logic.all_pull_request_participants(pull_request)
-        if _asana_user_id_from_github_handle(gh_handle) is not None
+        if (asana_user_id := _asana_user_id_from_github_handle(gh_handle)) is not None
     ]
+
 
 
 def _wrap_in_tag(

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -435,14 +435,24 @@ def _task_completion_from_pull_request(pull_request: PullRequest) -> StatusReaso
             " Request.",
         )
 
+
 def task_followers_from_comment(comment: Comment) -> List[str]:
-    return _task_followers_from_gh_handles(github_logic.comment_participants_and_mentions(comment))
+    return _task_followers_from_gh_handles(
+        github_logic.comment_participants_and_mentions(comment)
+    )
+
 
 def task_followers_from_review(review: Review) -> List[str]:
-    return _task_followers_from_gh_handles(github_logic.review_participants_and_mentions(review))
+    return _task_followers_from_gh_handles(
+        github_logic.review_participants_and_mentions(review)
+    )
+
 
 def task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
-    return _task_followers_from_gh_handles(github_logic.pull_request_participants(pull_request))
+    return _task_followers_from_gh_handles(
+        github_logic.pull_request_participants(pull_request)
+    )
+
 
 def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
     return [

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -30,7 +30,7 @@ def upsert_pull_request(pull_request: PullRequest):
     asana_controller.update_task(
         pull_request,
         task_id,
-        asana_helpers._task_followers_from_pull_request(pull_request),
+        asana_helpers.task_followers_from_pull_request(pull_request),
     )
 
 

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -27,7 +27,11 @@ def upsert_pull_request(pull_request: PullRequest):
         logger.info(
             f"Task found for pull request {pull_request_id}, updating task {task_id}"
         )
-    asana_controller.update_task(pull_request, task_id, asana_helpers._task_followers_from_pull_request(pull_request))
+    asana_controller.update_task(
+        pull_request,
+        task_id,
+        asana_helpers._task_followers_from_pull_request(pull_request),
+    )
 
 
 def _add_asana_task_to_pull_request(pull_request: PullRequest, task_id: str):
@@ -55,7 +59,9 @@ def upsert_comment(pull_request: PullRequest, comment: Comment):
         # TODO: Full sync
     else:
         asana_controller.upsert_github_comment_to_task(comment, task_id)
-        asana_controller.update_task(pull_request, task_id, asana_helpers.task_followers_from_comment(comment))
+        asana_controller.update_task(
+            pull_request, task_id, asana_helpers.task_followers_from_comment(comment)
+        )
 
 
 def upsert_review(pull_request: PullRequest, review: Review):
@@ -85,7 +91,10 @@ def upsert_review(pull_request: PullRequest, review: Review):
                 assign_pull_request_to_author(pull_request)
                 force_update_due_today = True
         asana_controller.update_task(
-            pull_request, task_id, asana_helpers.task_followers_from_review(review), force_update_due_today=force_update_due_today
+            pull_request,
+            task_id,
+            asana_helpers.task_followers_from_review(review),
+            force_update_due_today=force_update_due_today,
         )
 
 

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -27,7 +27,7 @@ def upsert_pull_request(pull_request: PullRequest):
         logger.info(
             f"Task found for pull request {pull_request_id}, updating task {task_id}"
         )
-    asana_controller.update_task(pull_request, task_id)
+    asana_controller.update_task(pull_request, task_id, asana_helpers._task_followers_from_pull_request(pull_request))
 
 
 def _add_asana_task_to_pull_request(pull_request: PullRequest, task_id: str):
@@ -55,7 +55,7 @@ def upsert_comment(pull_request: PullRequest, comment: Comment):
         # TODO: Full sync
     else:
         asana_controller.upsert_github_comment_to_task(comment, task_id)
-        asana_controller.update_task(pull_request, task_id)
+        asana_controller.update_task(pull_request, task_id, asana_helpers.task_followers_from_comment(comment))
 
 
 def upsert_review(pull_request: PullRequest, review: Review):
@@ -85,7 +85,7 @@ def upsert_review(pull_request: PullRequest, review: Review):
                 assign_pull_request_to_author(pull_request)
                 force_update_due_today = True
         asana_controller.update_task(
-            pull_request, task_id, force_update_due_today=force_update_due_today
+            pull_request, task_id, asana_helpers.task_followers_from_review(review), force_update_due_today=force_update_due_today
         )
 
 

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -226,25 +226,6 @@ def pull_request_participants(pull_request: PullRequest) -> List[str]:
     )
 
 
-def all_pull_request_participants(pull_request: PullRequest) -> List[str]:
-    return list(
-        set(
-            gh_handle
-            for gh_handle in (
-                [pull_request.author_handle()]
-                + pull_request.assignees()
-                + pull_request.reviewers()
-                + pull_request.requested_reviewers()
-                + _pull_request_commenters(pull_request)
-                + _pull_request_comment_mentions(pull_request)
-                + _pull_request_review_mentions(pull_request)
-                + _pull_request_body_mentions(pull_request)
-            )
-            if gh_handle
-        )
-    )
-
-
 def maybe_add_automerge_warning_comment(pull_request: PullRequest):
     """Adds comment warnings if automerge label is enabled"""
 

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -50,34 +50,8 @@ def _extract_mentions(text: str) -> List[str]:
     return re.findall(GITHUB_MENTION_REGEX, text)
 
 
-def _pull_request_comment_mentions(pull_request: PullRequest) -> List[str]:
-    comment_texts = [comment.body() for comment in pull_request.comments()]
-    return [
-        mention
-        for comment_text in comment_texts
-        for mention in _extract_mentions(comment_text)
-    ]
-
-
-def _pull_request_review_mentions(pull_request: PullRequest) -> List[str]:
-    review_texts = [review.body() for review in pull_request.reviews()] + [
-        comment.body()
-        for comments in [review.comments() for review in pull_request.reviews()]
-        for comment in comments
-    ]
-    return [
-        mention
-        for review_text in review_texts
-        for mention in _extract_mentions(review_text)
-    ]
-
-
 def _pull_request_body_mentions(pull_request: PullRequest) -> List[str]:
     return _extract_mentions(pull_request.body())
-
-
-def _pull_request_commenters(pull_request: PullRequest) -> List[str]:
-    return sorted(comment.author_handle() for comment in pull_request.comments())
 
 
 def comment_participants_and_mentions(comment: Comment) -> List[str]:

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -83,13 +83,19 @@ def _pull_request_commenters(pull_request: PullRequest) -> List[str]:
 def comment_participants_and_mentions(comment: Comment) -> List[str]:
     return list(set([comment.author_handle()] + _extract_mentions(comment.body())))
 
+
 def review_participants_and_mentions(review: Review) -> List[str]:
     review_texts = [review.body()] + [comment.body() for comment in review.comments()]
-    return list(set([review.author_handle()] + [
-        mention
-        for review_text in review_texts
-        for mention in _extract_mentions(review_text)
-    ]))
+    return list(
+        set(
+            [review.author_handle()]
+            + [
+                mention
+                for review_text in review_texts
+                for mention in _extract_mentions(review_text)
+            ]
+        )
+    )
 
 
 def pull_request_approved_before_merging(
@@ -204,6 +210,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
         )
     return False
 
+
 def pull_request_participants(pull_request: PullRequest) -> List[str]:
     return list(
         set(
@@ -217,6 +224,7 @@ def pull_request_participants(pull_request: PullRequest) -> List[str]:
             if gh_handle
         )
     )
+
 
 def all_pull_request_participants(pull_request: PullRequest) -> List[str]:
     return list(

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -786,6 +786,19 @@ class TestTaskFollowersFromReview(BaseClass):
         followers = src.asana.helpers.task_followers_from_review(review)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
+    def test_non_asana_user_is_not_a_follower(self):
+        unknown_github_user = build(
+            builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
+        )
+        review = (
+            builder.review()
+            .body("@github_unknown_user_login")
+            .author(unknown_github_user)
+            .build()
+        )
+        followers = src.asana.helpers.task_followers_from_review(review)
+        self.assertEqual(0, len(followers))
+
 
 class TestTaskFollowersFromComment(BaseClass):
     def test_commentor_is_a_follower(self):
@@ -804,31 +817,18 @@ class TestTaskFollowersFromComment(BaseClass):
         followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    # def test_non_asana_user_is_not_a_follower(self):
-    #     unknown_github_user = build(
-    #         builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
-    #     )
-    #     pull_request = build(
-    #         builder.pull_request()
-    #         .body("@github_unknown_user_login")
-    #         .author(unknown_github_user)
-    #         .assignee(unknown_github_user)
-    #         .review(
-    #             builder.review()
-    #             .body("@github_unknown_user_login")
-    #             .author(unknown_github_user)
-    #         )
-    #         .comment(
-    #             builder.comment()
-    #             .body("@github_unknown_user_login")
-    #             .author(unknown_github_user)
-    #         )
-    #         .requested_reviewer(unknown_github_user)
-    #     )
-    #     task_fields = src.asana.helpers.extract_task_fields_from_pull_request(
-    #         pull_request
-    #     )
-    #     self.assertEqual(0, len(task_fields["followers"]))
+    def test_non_asana_user_is_not_a_follower(self):
+        unknown_github_user = build(
+            builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
+        )
+        comment = (
+            builder.comment()
+            .body("@github_unknown_user_login")
+            .author(unknown_github_user)
+            .build()
+        )
+        followers = src.asana.helpers.task_followers_from_comment(comment)
+        self.assertEqual(0, len(followers))
 
 
 class TestExtractsInconsistentFieldsFromPullRequest(BaseClass):

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -711,9 +711,7 @@ class TestTaskFollowersFromPullRequest(BaseClass):
         pull_request = build(
             builder.pull_request().author(builder.user("github_test_user_login"))
         )
-        followers = src.asana.helpers.task_followers_from_pull_request(
-            pull_request
-        )
+        followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_assignee_is_a_follower(self):
@@ -722,9 +720,7 @@ class TestTaskFollowersFromPullRequest(BaseClass):
                 builder.user("github_test_user_login", "TEST_USER_ASANA_DOMAIN_USER_ID")
             )
         )
-        followers = src.asana.helpers.task_followers_from_pull_request(
-            pull_request
-        )
+        followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_requested_reviewer_is_a_follower(self):
@@ -739,16 +735,12 @@ class TestTaskFollowersFromPullRequest(BaseClass):
             )
             .requested_reviewers([builder.user("github_test_user_login")])
         )
-        followers = src.asana.helpers.task_followers_from_pull_request(
-            pull_request
-        )
+        followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_individual_that_is_at_mentioned_in_pr_body_is_a_follower(self):
         pull_request = build(builder.pull_request().body("@github_test_user_login"))
-        followers = src.asana.helpers.task_followers_from_pull_request(
-            pull_request
-        )
+        followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_non_asana_user_is_not_a_follower(self):
@@ -772,40 +764,44 @@ class TestTaskFollowersFromPullRequest(BaseClass):
             )
             .requested_reviewer(unknown_github_user)
         )
-        followers = src.asana.helpers.task_followers_from_pull_request(
-            pull_request
-        )
+        followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertEqual(0, len(followers))
+
 
 class TestTaskFollowersFromReview(BaseClass):
     def test_reviewer_is_a_follower(self):
-        review = builder.review().submitted_at("2020-02-13T14:59:57Z").state(ReviewState.CHANGES_REQUESTED).body("LGTM!").author(builder.user("github_test_user_login")).build()
-        followers = src.asana.helpers.task_followers_from_review(
-            review
+        review = (
+            builder.review()
+            .submitted_at("2020-02-13T14:59:57Z")
+            .state(ReviewState.CHANGES_REQUESTED)
+            .body("LGTM!")
+            .author(builder.user("github_test_user_login"))
+            .build()
         )
+        followers = src.asana.helpers.task_followers_from_review(review)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_individual_that_is_at_mentioned_in_review_body_is_a_follower(self):
         review = builder.review().body("@github_test_user_login").build()
-        followers = src.asana.helpers.task_followers_from_review(
-            review
-        )
+        followers = src.asana.helpers.task_followers_from_review(review)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
 
 class TestTaskFollowersFromComment(BaseClass):
     def test_commentor_is_a_follower(self):
-        comment = builder.comment().published_at("2020-01-13T14:59:58Z").body("LGTM!").author(builder.user("github_test_user_login")).build()
-        followers = src.asana.helpers.task_followers_from_comment(
-            comment
+        comment = (
+            builder.comment()
+            .published_at("2020-01-13T14:59:58Z")
+            .body("LGTM!")
+            .author(builder.user("github_test_user_login"))
+            .build()
         )
+        followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     def test_individual_that_is_at_mentioned_in_comment_is_a_follower(self):
         comment = builder.comment().body("@github_test_user_login").build()
-        followers = src.asana.helpers.task_followers_from_comment(
-            comment
-        )
+        followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
     # def test_non_asana_user_is_not_a_follower(self):

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -27,7 +27,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             add_asana_task_to_pr_mock.assert_called_with(pull_request, new_task_id)
 
         create_task_mock.assert_called_with(pull_request.repository_id())
-        update_task_mock.assert_called_with(pull_request, new_task_id)
+        update_task_mock.assert_called_with(pull_request, new_task_id, [])
 
         # Assert that the new task id was inserted into the table
         task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request.id())
@@ -51,7 +51,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         github_controller.upsert_pull_request(pull_request)
 
         create_task_mock.assert_not_called()
-        update_task_mock.assert_called_with(pull_request, existing_task_id)
+        update_task_mock.assert_called_with(pull_request, existing_task_id, [])
 
     @patch.object(github_client, "edit_pr_description")
     def test_add_asana_task_to_pull_request(self, edit_pr_mock):
@@ -86,7 +86,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         github_controller.upsert_comment(pull_request, comment)
 
         add_comment_mock.assert_called_with(comment, existing_task_id)
-        update_task_mock.assert_called_with(pull_request, existing_task_id)
+        update_task_mock.assert_called_with(pull_request, existing_task_id, [])
 
     @patch.object(asana_controller, "update_task")
     @patch.object(asana_controller, "upsert_github_comment_to_task")


### PR DESCRIPTION
Currently, any time an SGTM tasks gets updated, we look for _all_ participants on the PR (every comment/review etc) to add followers. This means that someone who comments on a PR can _never remove themself from the SGTM task_ since any new updates would re-add them.

This PR introduces a more incremental / selective approach to adding followers. It only adds comment followers for a comment when a comment is created/updated  for example, rather than looking at _every_ comment every time. This should also help with the efficiency of the function a bit.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204553465145631)