### PR TITLE
Allow disabling team member subscription to SGTM tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ For example, you may have a bot that automatically approves certain auto-generat
 **How to configure**:
 * Set an env variable of `TF_VAR_sgtm_feature__followup_review_github_users` to contain a comma-separated list of Github usernames that should have follow-up review
 
+### Turn off Github team task subscriptions to reduce inbox noise
+By default SGTM subscribes every member of a reviewing Github team to the SGTM task. You might want to turn this off if you want to use team reviewers as a marker for PR ownership or triage, but don't need every member of that team to see each PR.
+
+**How to configure**:
+* Set an env variable of `TF_VAR_sgtm_feature__disable_github_team_subscription` to `true`
+
 ## Installing a Virtual Environment for Python
 
 See [these instructions](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/) for help in

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,9 @@ SGTM_FEATURE__AUTOCOMPLETE_ENABLED = is_feature_flag_enabled(
 SGTM_FEATURE__AUTOMERGE_ENABLED = is_feature_flag_enabled(
     "SGTM_FEATURE__AUTOMERGE_ENABLED"
 )
+SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION = is_feature_flag_enabled(
+    "SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION"
+)
 SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = {
     github_username
     for github_username in os.getenv(

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -8,6 +8,7 @@ from enum import Enum, unique
 from src.github.helpers import pull_request_has_label
 from src.config import (
     SGTM_FEATURE__AUTOMERGE_ENABLED,
+    SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION,
     SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS,
 )
 
@@ -192,7 +193,7 @@ def pull_request_participants(pull_request: PullRequest) -> List[str]:
             for gh_handle in (
                 [pull_request.author_handle()]
                 + pull_request.assignees()
-                + pull_request.requested_reviewers()
+                + pull_request.requested_reviewers(include_team_members=not SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION)
                 + _pull_request_body_mentions(pull_request)
             )
             if gh_handle

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -193,7 +193,9 @@ def pull_request_participants(pull_request: PullRequest) -> List[str]:
             for gh_handle in (
                 [pull_request.author_handle()]
                 + pull_request.assignees()
-                + pull_request.requested_reviewers(include_team_members=not SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION)
+                + pull_request.requested_reviewers(
+                    include_team_members=not SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION
+                )
                 + _pull_request_body_mentions(pull_request)
             )
             if gh_handle

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -50,7 +50,7 @@ class PullRequest(object):
         ]
         self._assignees = self._assignees_from_raw()
 
-    def requested_reviewers(self) -> List[str]:
+    def requested_reviewers(self, include_team_members: bool = True) -> List[str]:
         reviewer_logins = set()
         for node in self._raw["reviewRequests"]["nodes"]:
             if (
@@ -61,6 +61,7 @@ class PullRequest(object):
             elif (
                 node["requestedReviewer"] is not None
                 and "members" in node["requestedReviewer"]
+                and include_team_members
             ):
                 for reviewer in node["requestedReviewer"]["members"].get("nodes", []):
                     reviewer_logins.add(reviewer["login"])

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -180,6 +180,7 @@ resource "aws_lambda_function" "sgtm" {
       API_KEYS_S3_KEY                    = var.api_key_s3_object,
       SGTM_FEATURE__AUTOMERGE_ENABLED    = var.sgtm_feature__automerge_enabled,
       SGTM_FEATURE__AUTOCOMPLETE_ENABLED = var.sgtm_feature__autocomplete_enabled,
+      SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION = var.sgtm_feature__disable_github_team_subscription,
       SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS = var.sgtm_feature__followup_review_github_users
     }
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,7 +62,7 @@ variable "sgtm_feature__autocomplete_enabled" {
 
 variable "sgtm_feature__disable_github_team_subscription" {
   type        = string
-  description = "'true' if behavior to not auto-subscribe github team members is enabled"
+  description = "'true' if behavior to auto-subscribe github team members is disabled"
   default     = "false"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,6 +60,12 @@ variable "sgtm_feature__autocomplete_enabled" {
   default     = "false"
 }
 
+variable "sgtm_feature__disable_github_team_subscription" {
+  type        = string
+  description = "'true' if behavior to not auto-subscribe github team members is enabled"
+  default     = "false"
+}
+
 variable "sgtm_feature__followup_review_github_users" {
   type        = string
   description = "A comma-separated list of Github usernames that require follow-up review after merge"

--- a/test/github/models/test_pull_request.py
+++ b/test/github/models/test_pull_request.py
@@ -14,6 +14,15 @@ class TestPullRequest(BaseClass):
         )
         self.assertEqual(["user1", "user2"], pull_request.requested_reviewers())
 
+    def test_requested_reviewers_github_team_subscription_disabled(self):
+        user = build(builder.user().login("user1"))
+        pull_request = build(
+            builder.pull_request()
+            .requested_reviewers([user])
+            .requested_reviewer_team("some_team", ["user1", "user2"])
+        )
+        self.assertEqual(["user1"], pull_request.requested_reviewers(include_team_members=False))
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests

--- a/test/github/models/test_pull_request.py
+++ b/test/github/models/test_pull_request.py
@@ -21,7 +21,9 @@ class TestPullRequest(BaseClass):
             .requested_reviewers([user])
             .requested_reviewer_team("some_team", ["user1", "user2"])
         )
-        self.assertEqual(["user1"], pull_request.requested_reviewers(include_team_members=False))
+        self.assertEqual(
+            ["user1"], pull_request.requested_reviewers(include_team_members=False)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This can help minimize Asana inbox noise when using Github teams as a review or triage marker

Test Plan:

Tested against https://github.com/Asana/codez/pull/195892:

```
rileypinkerton@Riley-Pinkerton-MacBook-Pro SGTM % python
Python 3.9.16 (main, Dec  7 2022, 10:06:04)
[Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import src.github.controller as github_controller; import src.github.graphql.client as graphql_client; import src.github.logic as github_logic
>>> pull_request = graphql_client.get_pull_request("PR_kwDOAr0gsc5QqbFl")
>>> github_logic.pull_request_participants(pull_request)
['binoche9', 'vsiao', 'marikobi', 'fanfan15', 'rpinkerton', 'asopkin', 'kharvd', 'suzyng83209', 'Asana', 'wenchienchen-asana', 'ericrafalovsky']
>>> exit()
rileypinkerton@Riley-Pinkerton-MacBook-Pro SGTM % export SGTM_FEATURE__DISABLE_GITHUB_TEAM_SUBSCRIPTION=true
rileypinkerton@Riley-Pinkerton-MacBook-Pro SGTM % python
Python 3.9.16 (main, Dec  7 2022, 10:06:04)
[Clang 14.0.0 (clang-1400.0.29.202)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import src.github.controller as github_controller; import src.github.graphql.client as graphql_client; import src.github.logic as github_logic
>>> pull_request = graphql_client.get_pull_request("PR_kwDOAr0gsc5QqbFl")
>>> github_logic.pull_request_participants(pull_request)
['binoche9', 'suzyng83209', 'ericrafalovsky', 'rpinkerton', 'Asana']
```

Run relevant tests:

```
rileypinkerton@Riley-Pinkerton-MacBook-Pro SGTM % python3 -m unittest test.github.models.test_pull_request
..
----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK
```



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204730388775722)