### PR TITLE
don't add followers if there are none

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -41,7 +41,8 @@ def update_task(
     if new_due_on is not None:
         update_task_fields["due_on"] = new_due_on
     asana_client.update_task(task_id, update_task_fields)
-    asana_client.add_followers(task_id, followers)
+    if len(followers) > 0:
+        asana_client.add_followers(task_id, followers)
     maybe_complete_tasks_on_merge(pull_request)
 
 


### PR DESCRIPTION
I noticed a few errors in the logs when `update_task` was being invoked. The asana client returns a `ValueError` when there is either an empty array of followers or an array of empty strings. I'll cover the first case and see if I need to cover the second.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1204763785273079)