### PR TITLE
Add href to asana anchor workaround

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -41,8 +41,12 @@ def update_task(
     if new_due_on is not None:
         update_task_fields["due_on"] = new_due_on
     asana_client.update_task(task_id, update_task_fields)
-    if len(followers) > 0:
+    # Add followers is optional because Asana should automatically add followers
+    # if the body contains well-formatted data-asana-gid fields
+    try:
         asana_client.add_followers(task_id, followers)
+    except Exception as e:
+        logger.error(f"Failed to add followers to task {task_id}: {e}")
     maybe_complete_tasks_on_merge(pull_request)
 
 

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -180,7 +180,7 @@ def _asana_user_url_from_github_user_handle(github_handle: str) -> Optional[str]
     user_id = _asana_user_id_from_github_handle(github_handle)
     if user_id is None:
         return None
-    return f'<a data-asana-gid="{user_id}"/>'
+    return _wrap_in_tag("A", attrs={"href": f"https://github.com/{github_handle}", "data-asana-gid": user_id})(github_handle)
 
 
 def _task_name_from_pull_request(pull_request: PullRequest) -> str:

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -91,7 +91,9 @@ def _build_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
 
 
 def _author_asana_user_id_from_pull_request(pull_request: PullRequest) -> Optional[str]:
-    return _asana_user_id_from_github_handle(pull_request.author_handle())
+    return dynamodb_client.get_asana_domain_user_id_from_github_handle(
+        github_handle=pull_request.author_handle()
+    )
 
 
 _custom_fields_to_extract_map = {
@@ -153,11 +155,9 @@ def _get_custom_field_value(custom_field: dict, value_name: str) -> Optional[str
 
 def _task_assignee_from_pull_request(pull_request: PullRequest) -> Optional[str]:
     assignee = pull_request.assignee()
-    return _asana_user_id_from_github_handle(assignee.login)
-
-
-def _asana_user_id_from_github_handle(github_handle: str) -> Optional[str]:
-    return dynamodb_client.get_asana_domain_user_id_from_github_handle(github_handle)
+    return dynamodb_client.get_asana_domain_user_id_from_github_handle(
+        github_handle=assignee.login
+    )
 
 
 def _asana_display_name_for_github_user(github_user: User) -> str:
@@ -177,7 +177,7 @@ def _asana_display_name_for_github_user(github_user: User) -> str:
 
 
 def _asana_user_url_from_github_user_handle(github_handle: str) -> Optional[str]:
-    user_id = _asana_user_id_from_github_handle(github_handle)
+    user_id = dynamodb_client.get_asana_domain_user_id_from_github_handle(github_handle)
     if user_id is None:
         return None
     return _wrap_in_tag(
@@ -196,7 +196,9 @@ def _task_name_from_pull_request(pull_request: PullRequest) -> str:
 def _transform_github_mentions_to_asana_mentions(text: str) -> str:
     def _github_mention_to_asana_mention(match: Match[str]) -> str:
         github_handle = match.group(1)
-        asana_user_id = _asana_user_id_from_github_handle(github_handle)
+        asana_user_id = dynamodb_client.get_asana_domain_user_id_from_github_handle(
+            github_handle
+        )
         if asana_user_id is None:
             # Return the full matched string, including the "@"
             return match.group(0)
@@ -462,8 +464,13 @@ def task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
 def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
     return [
         asana_user_id
-        for gh_handle in gh_handles
-        if (asana_user_id := _asana_user_id_from_github_handle(gh_handle)) is not None
+        for github_handle in gh_handles
+        if (
+            asana_user_id := dynamodb_client.get_asana_domain_user_id_from_github_handle(
+                github_handle
+            )
+        )
+        is not None
     ]
 
 

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -180,7 +180,13 @@ def _asana_user_url_from_github_user_handle(github_handle: str) -> Optional[str]
     user_id = _asana_user_id_from_github_handle(github_handle)
     if user_id is None:
         return None
-    return _wrap_in_tag("A", attrs={"href": f"https://github.com/{github_handle}", "data-asana-gid": user_id})(github_handle)
+    return _wrap_in_tag(
+        "A",
+        attrs={
+            "href": f"https://github.com/{github_handle}",
+            "data-asana-gid": user_id,
+        },
+    )(github_handle)
 
 
 def _task_name_from_pull_request(pull_request: PullRequest) -> str:

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -183,8 +183,8 @@ def _asana_user_url_from_github_user_handle(github_handle: str) -> Optional[str]
     return _wrap_in_tag(
         "A",
         attrs={
-            "href": f"https://github.com/{github_handle}",
             "data-asana-gid": user_id,
+            "href": f"https://github.com/{github_handle}",
         },
     )(github_handle)
 


### PR DESCRIPTION
# Add href to asana anchor workaround

## Summary
The asana client cannot properly handle links to deleted objects that directly reference the global id of the object. This manifests in errors that are difficult to handle when PR bodies contain references to de-activated users. Most frequently, this results is a slew of SGTM errors after intern season.

Instead, we can create an actual link to the github handle with a `data-asana-gid` attribute. If the user_id is valid, the anchor tag should not _do_ anything and be replaced with the appropriate asana task link. If the user_id is _not_ valid, then we should be able to use the anchor tag's href as a valid link.

## Test plan
- [x] a PR that references a de-activated asana user will properly link the github handle link and succeed in upserting the task
- [x] a PR that references an activated user still references the asana task and not the github handle

<img width="636" alt="image" src="https://github.com/Asana/SGTM/assets/22352112/d767b49b-fb52-4ff4-ade2-514ac4890150">
https://app.asana.com/0/1127984365697766/1205259139814521


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1205380760704777)