### PR TITLE
service asana tasks on new lines

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -292,26 +292,33 @@ def get_linked_task_ids(pull_request: PullRequest) -> List[str]:
     :return: Returns a list of task ids.
     """
     body_lines = pull_request.body().splitlines()
-    stripped_body_lines = (line.strip() for line in body_lines)
-    task_url_line = None
+    curr_line = 0
+    task_ids = []
     seen_asana_tasks_line = False
-    for line in stripped_body_lines:
-        if seen_asana_tasks_line:
-            task_url_line = line
-            break
-        if line.startswith("Asana tasks:"):
-            seen_asana_tasks_line = True
 
-    if task_url_line:
-        task_urls = task_url_line.split()
-        task_ids = []
-        for url in task_urls:
-            maybe_id = re.search("\d+(?!.*\d)", url)
-            if maybe_id is not None:
-                task_ids.append(maybe_id.group())
-        return task_ids
-    else:
-        return []
+    while curr_line < len(body_lines):
+        stripped_line = body_lines[curr_line].strip()
+        if stripped_line.startswith("Asana tasks:"):
+            seen_asana_tasks_line = True
+            curr_line += 1
+        elif seen_asana_tasks_line:
+            task_urls = stripped_line.split()
+            line_has_task_urls = False
+            for url in task_urls:
+                maybe_id = re.search("\d+(?!.*\d)", url)
+                if maybe_id is not None:
+                    line_has_task_urls = True
+                    task_ids.append(maybe_id.group())
+            
+            if line_has_task_urls:
+                curr_line += 1
+            else:
+                # no more task urls if the last one is not defined
+                break
+        else:
+            curr_line += 1
+
+    return task_ids
 
 
 def asana_comment_from_github_review(review: Review) -> str:

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -1,7 +1,7 @@
 import re
 from html import escape
 from datetime import datetime, timedelta
-from typing import Callable, Match, Optional, List, Dict
+from typing import Callable, Match, Optional, List, Dict, Set
 from src.dynamodb import client as dynamodb_client
 from src.github.models import (
     Comment,
@@ -284,7 +284,7 @@ _review_action_to_text_map: Dict[ReviewState, str] = {
 }
 
 
-def get_linked_task_ids(pull_request: PullRequest) -> List[str]:
+def get_linked_task_ids(pull_request: PullRequest) -> Set[str]:
     """
     Extracts linked task ids from the body of the PR.
     We expect linked tasks to be in the description in a line under the line containing "Asana tasks:".
@@ -293,7 +293,7 @@ def get_linked_task_ids(pull_request: PullRequest) -> List[str]:
     """
     body_lines = pull_request.body().splitlines()
     curr_line = 0
-    task_ids = []
+    task_ids = set()
     seen_asana_tasks_line = False
 
     while curr_line < len(body_lines):
@@ -308,7 +308,7 @@ def get_linked_task_ids(pull_request: PullRequest) -> List[str]:
                 maybe_id = re.search("\d+(?!.*\d)", url)
                 if maybe_id is not None:
                     line_has_task_urls = True
-                    task_ids.append(maybe_id.group())
+                    task_ids.add(maybe_id.group())
 
             if line_has_task_urls:
                 curr_line += 1

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -309,7 +309,7 @@ def get_linked_task_ids(pull_request: PullRequest) -> List[str]:
                 if maybe_id is not None:
                     line_has_task_urls = True
                     task_ids.append(maybe_id.group())
-            
+
             if line_has_task_urls:
                 curr_line += 1
             else:

--- a/test/asana/helpers/test_get_linked_task_ids.py
+++ b/test/asana/helpers/test_get_linked_task_ids.py
@@ -34,6 +34,20 @@ class TestGetLinkedTaskIds(BaseClass):
 
         self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), task_ids)
 
+    def test_gets_many_task_ids_newline_does_not_register_after_empty(self):
+        task_ids = ["1", "2", "3"]
+        url_list = [
+            f"https://app.asana.com/0/1162076285812014/{id}/f " for id in task_ids
+        ]
+        url_string = reduce(lambda url_str, url: url_str + "\n" + url, url_list)
+        pull_request = build(
+            builder.pull_request().body(
+                f"Blah blah blah\nblah\n                Asana tasks:\n\n{url_string}"
+            )
+        )
+
+        self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), [])
+
     def test_returns_empty_list_if_no_asana_tasks_line(self):
         pull_request = build(builder.pull_request().body(f"Blah blah blah\nblah\n"))
 

--- a/test/asana/helpers/test_get_linked_task_ids.py
+++ b/test/asana/helpers/test_get_linked_task_ids.py
@@ -20,6 +20,20 @@ class TestGetLinkedTaskIds(BaseClass):
 
         self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), task_ids)
 
+    def test_gets_many_task_ids_newline(self):
+        task_ids = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        url_list = [
+            f"https://app.asana.com/0/1162076285812014/{id}/f " for id in task_ids
+        ]
+        url_string = reduce(lambda url_str, url: url_str + "\n" + url, url_list)
+        pull_request = build(
+            builder.pull_request().body(
+                f"Blah blah blah\nblah\n                Asana tasks:\n{url_string}"
+            )
+        )
+
+        self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), task_ids)
+
     def test_returns_empty_list_if_no_asana_tasks_line(self):
         pull_request = build(builder.pull_request().body(f"Blah blah blah\nblah\n"))
 

--- a/test/asana/helpers/test_get_linked_task_ids.py
+++ b/test/asana/helpers/test_get_linked_task_ids.py
@@ -7,7 +7,7 @@ from functools import reduce
 
 class TestGetLinkedTaskIds(BaseClass):
     def test_gets_many_task_ids(self):
-        task_ids = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        task_ids = {"1", "2", "3", "4", "5", "6", "7", "8", "9"}
         url_list = [
             f"https://app.asana.com/0/1162076285812014/{id}/f " for id in task_ids
         ]
@@ -21,7 +21,7 @@ class TestGetLinkedTaskIds(BaseClass):
         self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), task_ids)
 
     def test_gets_many_task_ids_newline(self):
-        task_ids = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
+        task_ids = {"1", "2", "3", "4", "5", "6", "7", "8", "9"}
         url_list = [
             f"https://app.asana.com/0/1162076285812014/{id}/f " for id in task_ids
         ]
@@ -35,7 +35,7 @@ class TestGetLinkedTaskIds(BaseClass):
         self.assertCountEqual(asana_helpers.get_linked_task_ids(pull_request), task_ids)
 
     def test_gets_many_task_ids_newline_does_not_register_after_empty(self):
-        task_ids = ["1", "2", "3"]
+        task_ids = {"1", "2", "3"}
         url_list = [
             f"https://app.asana.com/0/1162076285812014/{id}/f " for id in task_ids
         ]


### PR DESCRIPTION
# Service asana tasks on new lines

## Summary
Complete tasks on merge capability will not process tasks that are separated by newlines. This is fairly easy to do and should be handled so this changes the implementation for getting asana task links to complete.

Will handle:
```
Asana tasks:
link
link
link
```
```
Asana tasks:
link link
link link
```

Will not handle:
```
Asana tasks:
link (this one succeeds)

link (this one does not)
```

## Test plan
- added 2 more test cases


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1205559873552451)