### PR TITLE
Add Review Status To SGTM Sync

### DIFF
--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -80,6 +80,7 @@ CUSTOM_FIELDS = [
             EnumOption(name="Needs Review", color="yellow"),
             EnumOption(name="Changes Requested", color="red"),
             EnumOption(name="Approved", color="green"),
+            EnumOption(name="Draft", color="blue")
         ],
     ),
 ]

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -80,7 +80,7 @@ CUSTOM_FIELDS = [
             EnumOption(name="Needs Review", color="yellow"),
             EnumOption(name="Changes Requested", color="red"),
             EnumOption(name="Approved", color="green"),
-            EnumOption(name="Draft", color="blue"),
+            EnumOption(name="Draft", color="purple"),
         ],
     ),
 ]

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -78,7 +78,7 @@ CUSTOM_FIELDS = [
         name="Review Status",
         enum_options=[
             EnumOption(name="Needs Review", color="yellow"),
-            EnumOption(name="Requested Changes", color="red"),
+            EnumOption(name="Changes Requested", color="red"),
             EnumOption(name="Approved", color="green"),
         ],
     ),

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -80,7 +80,7 @@ CUSTOM_FIELDS = [
             EnumOption(name="Needs Review", color="yellow"),
             EnumOption(name="Changes Requested", color="red"),
             EnumOption(name="Approved", color="green"),
-            EnumOption(name="Draft", color="blue")
+            EnumOption(name="Draft", color="blue"),
         ],
     ),
 ]

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -74,6 +74,14 @@ CUSTOM_FIELDS = [
         ],
     ),
     PeopleCustomField(name="Author (SGTM)"),
+    EnumCustomField(
+        name="Review Status",
+        enum_options=[
+            EnumOption(name="Needs Review", color="yellow"),
+            EnumOption(name="Requested Changes", color="red"),
+            EnumOption(name="Approved", color="green"),
+        ],
+    ),
 ]
 
 

--- a/scripts/setup_sgtm_tasks_project.py
+++ b/scripts/setup_sgtm_tasks_project.py
@@ -80,7 +80,7 @@ CUSTOM_FIELDS = [
             EnumOption(name="Needs Review", color="yellow"),
             EnumOption(name="Changes Requested", color="red"),
             EnumOption(name="Approved", color="green"),
-            EnumOption(name="Draft", color="purple"),
+            EnumOption(name="Not Ready", color="purple"),
         ],
     ),
 ]

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -129,7 +129,7 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     We currently expect the project to have three custom fields with its corresponding enum options:
         • PR Status: "Open", "Draft", "Closed", "Merged"
         • Build: "Success", "Failure"
-        • Review Status: "Needs Review", "Requested Changes", "Approved"
+        • Review Status: "Needs Review", "Changes Requested", "Approved"
     """
     repository_id = pull_request.repository_id()
     project_id = dynamodb_client.get_asana_id_from_github_node_id(repository_id)

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -88,21 +88,9 @@ def _task_status_from_pull_request(pull_request: PullRequest) -> str:
 def _review_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
     if pull_request.is_draft():
         return "Not Ready"
-    approval_or_changes_requested_reviews = sorted(
-        (
-            review
-            for review in pull_request.reviews()
-            if review.is_approval_or_changes_requested()
-        ),
-        key=lambda r: r.submitted_at(),
-    )
-
-    if len(approval_or_changes_requested_reviews) == 0:
-        # We didn't find any reviews
+    elif pull_request.is_needs_review():
         return "Needs Review"
-
-    latest_review = approval_or_changes_requested_reviews[-1]
-    if latest_review.is_approval():
+    elif pull_request.is_approved():
         return "Approved"
     else:
         return "Changes Requested"

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -84,7 +84,10 @@ def _task_status_from_pull_request(pull_request: PullRequest) -> str:
     else:
         return "Draft" if pull_request.is_draft() else "Open"
 
+
 def _review_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
+    if pull_request.is_draft():
+        return "Draft"
     approval_or_changes_requested_reviews = sorted(
         (
             review
@@ -129,7 +132,7 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     We currently expect the project to have three custom fields with its corresponding enum options:
         • PR Status: "Open", "Draft", "Closed", "Merged"
         • Build: "Success", "Failure"
-        • Review Status: "Needs Review", "Changes Requested", "Approved"
+        • Review Status: "Needs Review", "Changes Requested", "Approved", "Draft"
     """
     repository_id = pull_request.repository_id()
     project_id = dynamodb_client.get_asana_id_from_github_node_id(repository_id)
@@ -141,7 +144,6 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
         # TODO: Full sync
         return {}
     else:
-        # TODO ensure our custom filed for review status is in the project
         custom_field_map = {
             cf["custom_field"]["name"]: cf["custom_field"]
             for cf in asana_client.get_project_custom_fields(project_id)

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -87,7 +87,7 @@ def _task_status_from_pull_request(pull_request: PullRequest) -> str:
 
 def _review_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
     if pull_request.is_draft():
-        return "Draft"
+        return "Not Ready"
     approval_or_changes_requested_reviews = sorted(
         (
             review
@@ -132,7 +132,7 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     We currently expect the project to have three custom fields with its corresponding enum options:
         • PR Status: "Open", "Draft", "Closed", "Merged"
         • Build: "Success", "Failure"
-        • Review Status: "Needs Review", "Changes Requested", "Approved", "Draft"
+        • Review Status: "Needs Review", "Changes Requested", "Approved", "Not Ready"
     """
     repository_id = pull_request.repository_id()
     project_id = dynamodb_client.get_asana_id_from_github_node_id(repository_id)

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -84,6 +84,26 @@ def _task_status_from_pull_request(pull_request: PullRequest) -> str:
     else:
         return "Draft" if pull_request.is_draft() else "Open"
 
+def _review_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
+    approval_or_changes_requested_reviews = sorted(
+        (
+            review
+            for review in pull_request.reviews()
+            if review.is_approval_or_changes_requested()
+        ),
+        key=lambda r: r.submitted_at(),
+    )
+
+    if len(approval_or_changes_requested_reviews) == 0:
+        # We didn't find any reviews
+        return "Needs Review"
+
+    latest_review = approval_or_changes_requested_reviews[-1]
+    if latest_review.is_approval():
+        return "Approved"
+    else:
+        return "Changes Requested"
+
 
 def _build_status_from_pull_request(pull_request: PullRequest) -> Optional[str]:
     build_status = pull_request.build_status()
@@ -100,14 +120,16 @@ _custom_fields_to_extract_map = {
     "PR Status": _task_status_from_pull_request,
     "Build": _build_status_from_pull_request,
     "Author (SGTM)": _author_asana_user_id_from_pull_request,
+    "Review Status": _review_status_from_pull_request,
 }
 
 
 def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     """
-    We currently expect the project to have two custom fields with its corresponding enum options:
+    We currently expect the project to have three custom fields with its corresponding enum options:
         • PR Status: "Open", "Draft", "Closed", "Merged"
         • Build: "Success", "Failure"
+        • Review Status: "Needs Review", "Requested Changes", "Approved"
     """
     repository_id = pull_request.repository_id()
     project_id = dynamodb_client.get_asana_id_from_github_node_id(repository_id)
@@ -119,6 +141,7 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
         # TODO: Full sync
         return {}
     else:
+        # TODO ensure our custom filed for review status is in the project
         custom_field_map = {
             cf["custom_field"]["name"]: cf["custom_field"]
             for cf in asana_client.get_project_custom_fields(project_id)

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -150,9 +150,32 @@ class PullRequest(object):
     def is_draft(self) -> bool:
         return self._raw["isDraft"]
 
-    # A PR is considered approved if it has at least one approval and every time changes were requested by a reviewer
-    # that same reviewer later approved.
+    # A PR is considered approved if the latest review has an approve review status.
     def is_approved(self) -> bool:
+        if self.is_draft():
+            return False
+        approval_or_changes_requested_reviews = sorted(
+            (
+                review
+                for review in self.reviews()
+                if review.is_approval_or_changes_requested()
+            ),
+            key=lambda r: r.submitted_at(),
+        )
+
+        if len(approval_or_changes_requested_reviews) == 0:
+            return False
+
+        latest_review = approval_or_changes_requested_reviews[-1]
+        if latest_review.is_approval():
+            return True
+        else:
+            return False
+
+
+
+
+
         if len(self.reviews()) > 0:
             reviews = self.reviews()
             reviews.sort(key=lambda review: review.submitted_at())

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -150,7 +150,9 @@ class PullRequest(object):
     def is_draft(self) -> bool:
         return self._raw["isDraft"]
 
-    # A PR is considered approved if the latest review has an approve review status.
+    # A PR is considered to be approved if the latest review attached to the PR
+    # is approved. If the latest review status is changes requested, the PR is not
+    # considered to be approved.
     def is_approved(self) -> bool:
         if self.is_draft():
             return False

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -308,7 +308,7 @@ class TestMaybeAutomergePullRequest(unittest.TestCase):
                     .submitted_at("2020-01-12T14:59:58Z")
                     .state(ReviewState.APPROVED)
                     .author(author_2),
-                     builder.review()
+                    builder.review()
                     .submitted_at("2020-01-13T14:59:58Z")
                     .state(ReviewState.CHANGES_REQUESTED)
                     .author(author_1),


### PR DESCRIPTION
- added review status CF to SGTM sync. There are 4 possible values: Changes Requested, Not Ready, Approved, Needs Review. This will help folks figure out if a PR needs to be reviewed or not.
- modified the approved status for Pull Request objects to utilize the latest review's status to determine if a PR is considered to be "Approved" or "Changes Requested"

### Testing
General format
```
In [1]: import src.github.controller as github_controller; import src.github.graphql.client as graphql_client

In [2]: pull_request = graphql_client.get_pull_request("PR_kwDOAr0gsc5elLoP")

In [3]: github_controller.upsert_pull_request(pull_request)
```

I tested the controller with a [PR ](https://github.com/Asana/codez/pull/224261)I already had up that had the changes requested status. I was able to modify the Asana task to reflect this new status (changes request).
I then asked someone else to approve the pr changes to approved.
I then asked someone else to request changes and the pr status changes and it goes back to needs changes. Task logs:
![image](https://github.com/Asana/SGTM/assets/144956175/c19401d9-4f0f-4ffb-beb5-0389120932df)

I created a draft PR too and the Draft status was also set. Also tested going from needs review -> draft on the pr and works as expected.

Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1205891141351354)