### PR TITLE
Add logging and move graphql queries out of lock

### DIFF
--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -11,6 +11,7 @@ from src.config import (
 
 
 def upsert_pull_request(pull_request: PullRequest):
+    logger.info("Updating/creating asana task for pull request")
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id is None:

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -11,7 +11,6 @@ from src.config import (
 
 
 def upsert_pull_request(pull_request: PullRequest):
-    logger.info("Updating/creating asana task for pull request")
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id is None:

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -288,7 +288,9 @@ def maybe_automerge_pull_request_and_rerun_stale_checks(
             pull_request.is_mergeable() and pull_request.is_approved()
         )
 
-    logger.info(f"Pull request status: test {pull_request.is_build_successful()}, mergeable {pull_request.is_mergeable()}, approved {pull_request.is_approved()}")
+    logger.info(
+        f"Pull request status: test {pull_request.is_build_successful()}, mergeable {pull_request.is_mergeable()}, approved {pull_request.is_approved()}"
+    )
     logger.info(
         f"{pull_request.id()} is {'' if is_pull_request_ready_for_automerge else 'not '}ready for automerge"
     )

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -215,6 +215,7 @@ def pull_request_participants(pull_request: PullRequest) -> List[str]:
 def maybe_add_automerge_warning_comment(pull_request: PullRequest):
     """Adds comment warnings if automerge label is enabled"""
 
+    logger.info("Running maybe add automerge warning comment")
     if SGTM_FEATURE__AUTOMERGE_ENABLED:
         owner = pull_request.repository_owner_handle()
         repo_name = pull_request.repository_name()
@@ -249,6 +250,7 @@ def maybe_automerge_pull_request_and_rerun_stale_checks(
 ) -> bool:
     is_pull_request_ready_for_automerge = False
     did_rerun_stale_required_checks = False
+    logger.info("Running maybe automerge pull request and rerun stale checks")
     if (
         not SGTM_FEATURE__AUTOMERGE_ENABLED
         or pull_request.closed()
@@ -289,7 +291,7 @@ def maybe_automerge_pull_request_and_rerun_stale_checks(
         )
 
     logger.info(
-        f"Pull request status: test {pull_request.is_build_successful()}, mergeable {pull_request.is_mergeable()}, approved {pull_request.is_approved()}"
+        f"Pull request {pull_request.id()} status: test result: {pull_request.is_build_successful()}, mergeable: {pull_request.is_mergeable()}, approved: {pull_request.is_approved()}"
     )
     logger.info(
         f"{pull_request.id()} is {'' if is_pull_request_ready_for_automerge else 'not '}ready for automerge"

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -251,6 +251,7 @@ def maybe_automerge_pull_request_and_rerun_stale_checks(
     is_pull_request_ready_for_automerge = False
     did_rerun_stale_required_checks = False
     logger.info("Running maybe automerge pull request and rerun stale checks")
+    logger.info(f"Pull request status: {pull_request.to_raw()}")
     if (
         not SGTM_FEATURE__AUTOMERGE_ENABLED
         or pull_request.closed()

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -288,6 +288,7 @@ def maybe_automerge_pull_request_and_rerun_stale_checks(
             pull_request.is_mergeable() and pull_request.is_approved()
         )
 
+    logger.info(f"Pull request status: test {pull_request.is_build_successful()}, mergeable {pull_request.is_mergeable()}, approved {pull_request.is_approved()}")
     logger.info(
         f"{pull_request.id()} is {'' if is_pull_request_ready_for_automerge else 'not '}ready for automerge"
     )

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -26,7 +26,7 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
 # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
 def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
     action, issue, comment = itemgetter("action", "issue", "comment")(payload)
-    logger.info(f"issue: {issue['node_id']}, comment: {comment['html_url']}")
+    logger.info(f"issue: {issue['node_id']}, comment: {comment['url']}")
 
     issue_id = issue["node_id"]
     comment_id = comment["node_id"]

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -14,8 +14,8 @@ from src.github.models import PullRequestReviewComment, Review
 # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
 def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
+    pull_request = graphql_client.get_pull_request(pull_request_id)
     with dynamodb_lock(pull_request_id):
-        pull_request = graphql_client.get_pull_request(pull_request_id)
         # a label change will trigger this webhook, so it may trigger automerge
         github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
         github_logic.maybe_add_automerge_warning_comment(pull_request)
@@ -26,6 +26,7 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
 # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment
 def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
     action, issue, comment = itemgetter("action", "issue", "comment")(payload)
+    logger.info(f"issue: {issue['node_id']}, comment: {comment['html_url']}")
 
     issue_id = issue["node_id"]
     comment_id = comment["node_id"]
@@ -50,11 +51,10 @@ def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
 def _handle_pull_request_review_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
     review_id = payload["review"]["node_id"]
-
+    pull_request, review = graphql_client.get_pull_request_and_review(
+        pull_request_id, review_id
+    )
     with dynamodb_lock(pull_request_id):
-        pull_request, review = graphql_client.get_pull_request_and_review(
-            pull_request_id, review_id
-        )
         github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
         github_controller.upsert_review(pull_request, review)
     return HttpResponse("200")
@@ -89,31 +89,32 @@ def _handle_pull_request_review_comment(payload: dict):
     # This is NOT the node_id, but is a numeric string (the databaseId field).
     review_database_id = payload["comment"]["pull_request_review_id"]
 
-    with dynamodb_lock(pull_request_id):
-        if action in ("created", "edited"):
-            pull_request, comment = graphql_client.get_pull_request_and_comment(
-                pull_request_id, comment_id
+    if action in ("created", "edited"):
+        pull_request, comment = graphql_client.get_pull_request_and_comment(
+            pull_request_id, comment_id
+        )
+        if not isinstance(comment, PullRequestReviewComment):
+            raise Exception(
+                f"Unexpected comment type {type(PullRequestReviewComment)} for pull"
+                " request review"
             )
-            if not isinstance(comment, PullRequestReviewComment):
-                raise Exception(
-                    f"Unexpected comment type {type(PullRequestReviewComment)} for pull"
-                    " request review"
-                )
-            review: Optional[Review] = Review.from_comment(comment)
-        elif action == "deleted":
-            pull_request = graphql_client.get_pull_request(pull_request_id)
-            review = graphql_client.get_review_for_database_id(
-                pull_request_id, review_database_id
-            )
-            if review is None:
-                # If we deleted the last comment from a review, Github might have deleted the review.
-                # If so, we should delete the Asana comment.
-                logger.info("No review found in Github. Deleting the Asana comment.")
-                github_controller.delete_comment(comment_id)
-        else:
-            raise ValueError(f"Unexpected action: {action}")
+        review: Optional[Review] = Review.from_comment(comment)
+    elif action == "deleted":
+        pull_request = graphql_client.get_pull_request(pull_request_id)
+        review = graphql_client.get_review_for_database_id(
+            pull_request_id, review_database_id
+        )
+    else:
+        raise ValueError(f"Unexpected action: {action}")
 
+    with dynamodb_lock(pull_request_id):
+        if review is None:
+            # If we deleted the last comment from a review, Github might have deleted the review.
+            # If so, we should delete the Asana comment.
+            logger.info("No review found in Github. Deleting the Asana comment.")
+            github_controller.delete_comment(comment_id)
         if review is not None:
+            logger.info("Updating review comment")
             github_controller.upsert_review(pull_request, review)
 
         return HttpResponse("200")


### PR DESCRIPTION
Logs the status of PRs to explain why PR is not ready for automerge
Logs when function to update asana task is called
Logs PR node id and comment url when issue_comment webhook is called

Moves graphql queries out of dynamodb lock where possible


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1206499382584755)