### PR TITLE
update dynamodb lock and move logic functions out of lock

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -32,6 +32,7 @@ def update_task(
     update_task_fields = asana_helpers.extract_task_fields_from_pull_request(
         pull_request
     )
+    logger.info(f"Updating task {task_id} with fields: {update_task_fields}")
     task = asana_client.get_task(task_id)
     new_due_on = (
         asana_helpers.today_str()

--- a/src/dynamodb/lock.py
+++ b/src/dynamodb/lock.py
@@ -23,7 +23,6 @@ lock_client = DynamoDBLockClient(
 def dynamodb_lock(
     lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=45)
 ):
-    # TODO: Make this match get-lock-client in the clojure code
     lock = lock_client.acquire_lock(
         lock_name, sort_key=lock_name, retry_timeout=retry_timeout
     )

--- a/src/dynamodb/lock.py
+++ b/src/dynamodb/lock.py
@@ -21,7 +21,7 @@ lock_client = DynamoDBLockClient(
 
 @contextmanager
 def dynamodb_lock(
-    lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=20)
+    lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=45)
 ):
     # TODO: Make this match get-lock-client in the clojure code
     lock = lock_client.acquire_lock(

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -15,10 +15,10 @@ from src.github.models import PullRequestReviewComment, Review
 def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
     pull_request = graphql_client.get_pull_request(pull_request_id)
-    # a label change will trigger this webhook, so it may trigger automerge
-    github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
-    github_logic.maybe_add_automerge_warning_comment(pull_request)
     with dynamodb_lock(pull_request_id):
+        # a label change will trigger this webhook, so it may trigger automerge
+        github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
+        github_logic.maybe_add_automerge_warning_comment(pull_request)
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")
 
@@ -55,8 +55,8 @@ def _handle_pull_request_review_webhook(payload: dict) -> HttpResponse:
     pull_request, review = graphql_client.get_pull_request_and_review(
         pull_request_id, review_id
     )
-    github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
     with dynamodb_lock(pull_request_id):
+        github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
         github_controller.upsert_review(pull_request, review)
     return HttpResponse("200")
 
@@ -130,8 +130,8 @@ def _handle_status_webhook(payload: dict) -> HttpResponse:
         logger.warn(f"No pull request found for commit id {commit_id}")
         return HttpResponse("200")
 
-    github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
     with dynamodb_lock(pull_request.id()):
+        github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")
 
@@ -150,8 +150,8 @@ def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
         repository_node_id, pull_request_number
     )
 
-    github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
     with dynamodb_lock(pull_request.id()):
+        github_logic.maybe_automerge_pull_request_and_rerun_stale_checks(pull_request)
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")
 


### PR DESCRIPTION
Updates dynamodb lock timeout to 45s, and moves github_logic function calls out of the lock. Only github_controller and asana_controller interact with dynamodb, and github_logic doesn't call either so it does not need to be inside the lock.

Also adding some logging to task update function to try to debug issues we are seeing there

https://app.asana.com/0/1149418478823393/1206470410132273/f


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1206529515761826)