### PR TITLE
Allow SGTM to be setup with Terraform Cloud 

### DIFF
--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -6,12 +6,22 @@ generate "backend" {
   if_exists = "overwrite_terragrunt"
   contents = <<EOF
 terraform {
+%{ if get_env("TF_VAR_terraform_backend_use_tfc", false) }
   backend "remote" {
-    organization = "asana"
+    organization = "${get_env("TF_VAR_terraform_backend_organization_name")}"
     workspaces {
-      name = "sgtm"
+      name = "${get_env("TF_VAR_terraform_backend_workspace_name")}"
     }
   }
+%{ else }
+  backend "s3" {
+    bucket = "${get_env("TF_VAR_terraform_backend_s3_bucket_name")}"
+    dynamodb_table = "sgtm_terraform_state_lock"
+    region = "us-east-1"
+
+    key = "${path_relative_to_include()}/terraform.tfstate"
+  }
+%{ endif }
 }
 EOF
 }

--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -1,19 +1,17 @@
 # Should be able to use vars directly in main.tf, but can't
 # in backend configuration, so we use terragrunt for now.
 # See: https://github.com/hashicorp/terraform/issues/13022
-remote_state {
-  backend = "s3"
-
-  generate = {
-    path      = "backend.tf"
-    if_exists = "overwrite_terragrunt"
+generate "backend" {
+  path = "backend.tf"
+  if_exists = "overwrite_terragrunt"
+  contents = <<EOF
+terraform {
+  backend "remote" {
+    organization = "asana"
+    workspaces {
+      name = "sgtm"
+    }
   }
-
-  config = {
-    bucket = "${get_env("TF_VAR_terraform_backend_s3_bucket_name")}"
-    dynamodb_table = "sgtm_terraform_state_lock"
-    region = "us-east-1"
-
-    key = "${path_relative_to_include()}/terraform.tfstate"
-  }
+}
+EOF
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,11 +35,13 @@ variable "lambda_runtime" {
 
 variable "terraform_backend_s3_bucket_name" {
   type        = string
+  default     = ""
   description = "S3 bucket name to store the Terraform state"
 }
 
 variable "terraform_backend_dynamodb_lock_table" {
   type        = string
+  default     = ""
   description = "The DynamoDb table to store the Terraform state lock"
 }
 
@@ -51,11 +53,13 @@ variable "terraform_backend_use_tfc" {
 
 variable "terraform_backend_tfc_organization" {
   type        = string
+  default     = ""
   description = "The Terraform Cloud organization to use as the remote backend. Must be provided if terraform_backend_use_tfc is true."
 }
 
 variable "terraform_backend_tfc_workspace" {
   type        = string
+  default     = ""
   description = "The Terraform Cloud workspace to use as the remote backend. Must be provided if terraform_backend_use_tfc is true."
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,22 @@ variable "terraform_backend_dynamodb_lock_table" {
   description = "The DynamoDb table to store the Terraform state lock"
 }
 
+variable "terraform_backend_use_tfc" {
+  type        = bool
+  default     = false
+  description = "Whether to use Terraform Cloud as the remote backend. Defaults to false."
+}
+
+variable "terraform_backend_tfc_organization" {
+  type        = string
+  description = "The Terraform Cloud organization to use as the remote backend. Must be provided if terraform_backend_use_tfc is true."
+}
+
+variable "terraform_backend_tfc_workspace" {
+  type        = string
+  description = "The Terraform Cloud workspace to use as the remote backend. Must be provided if terraform_backend_use_tfc is true."
+}
+
 variable "asana_users_project_id" {
   type        = string
   description = "Project ID that holds the tasks that map Github handles to Asana user ids"


### PR DESCRIPTION
SGTM has only used the s3-backed terraform backend with terragrunt for a while. Asana is moving to using just Terraform Cloud so we want to enable SGTM to move to TFC as well.

Changes:
* Created a new generate block with conditionals depending on which remote backend wants to use. This should generate a well-formatted `backend.tf`
* Still kept the old pathway for s3 remote backend
* Added 3 new TF vars to define the backend configuration
* Updated docs and instructions for deployment


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1206682923832152)