### PR TITLE
[Deprecate Asanas in Github project] Attempt to read asana user gids from S3 instead of from DynamoDB

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,5 @@ black==22.3.0
 moto==4.1.7
 mypy==1.1.1
 types-mock==4.0.12
+typeguard>=4
+mypy-boto3-s3~=1.34.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ python-dynamodb-lock==0.9.1
 requests==2.25.1
 types-requests==2.25.1
 sgqlc==8.1
-typing-extensions==4.1.1
+typing-extensions~=4.6

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,3 @@
+# src
+
+This directory contains the source code that is bundled and uploaded to SGTM's AWS lambda function.

--- a/src/config.py
+++ b/src/config.py
@@ -13,6 +13,9 @@ LOCK_TABLE = os.getenv("LOCK_TABLE", "sgtm-lock")
 OBJECTS_TABLE = os.getenv("OBJECTS_TABLE", "sgtm-objects")
 USERS_TABLE = os.getenv("USERS_TABLE", "sgtm-users")
 ASANA_USERS_PROJECT_ID = os.getenv("ASANA_USERS_PROJECT_ID", "")
+GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH = os.getenv(
+    "GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH", ""
+)
 
 # Feature flags
 def is_feature_flag_enabled(flag_name: str) -> bool:

--- a/src/dynamodb/client.py
+++ b/src/dynamodb/client.py
@@ -1,10 +1,17 @@
+from contextlib import closing
+import json
+import traceback
 from typing import Iterator, Optional, List, Tuple
 from typing_extensions import TypedDict
 
 import boto3  # type: ignore
 from botocore.exceptions import NoRegionError  # type: ignore
 
-from src.config import OBJECTS_TABLE, USERS_TABLE
+from src.config import (
+    OBJECTS_TABLE,
+    USERS_TABLE,
+    GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH,
+)
 from src.logger import logger
 from src.utils import memoize
 
@@ -115,10 +122,14 @@ class DynamoDbClient(object):
 
     # USERS TABLE
 
-    def bulk_insert_github_handle_to_asana_user_id_mapping(
+    def DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping(
         self, gh_and_asana_ids: List[Tuple[str, str]]
     ):
-        """Insert multiple mappings from github handle to Asana user ids."""
+        """Insert multiple mappings from github handle to Asana user ids.
+
+        This is marked as deprecated since we'd like to read SGTM user info from S3 instead of
+        DynamoDB.
+        """
         items = [
             {
                 self.GITHUB_HANDLE_KEY: {"S": gh_handle},
@@ -129,13 +140,16 @@ class DynamoDbClient(object):
         return self.bulk_insert_items_in_batches(USERS_TABLE, items)
 
     @memoize
-    def get_asana_domain_user_id_from_github_handle(
+    def DEPRECATED_get_asana_domain_user_id_from_github_handle(
         self, github_handle: str
     ) -> Optional[str]:
         """
         Retrieves the Asana domain user-id associated with a specific GitHub user login, or None,
         if no such association exists. User-id associations are created manually via an external process.
         TODO: document this process, and create scripts to encapsulate it
+
+        This is marked as deprecated since we'd like to read SGTM user info from S3 instead of
+        DynamoDB.
         """
         response = self.client.get_item(
             TableName=USERS_TABLE,
@@ -146,9 +160,12 @@ class DynamoDbClient(object):
         else:
             return None
 
-    def get_all_user_items(self) -> Iterator[DynamoDbUserItem]:
+    def DEPRECATED_get_all_user_items(self) -> Iterator[DynamoDbUserItem]:
         """
         Get all DynamoDb items from the USERS_TABLE
+
+        This is marked as deprecated since we'd like to read SGTM user info from S3 instead of
+        DynamoDB.
         """
         response = self.client.scan(TableName=USERS_TABLE)
         yield from response["Items"]
@@ -176,6 +193,72 @@ class DynamoDbClient(object):
         )
 
 
+class S3Client(object):
+    """
+    Encapsulates S3 client interface, as exposed to the world. There is a single (singleton) instance of
+    S3Client in the process, which is lazily created upon the first request.
+    """
+
+    # the singleton instance of S3Client
+    _singleton = None
+
+    def __init__(self):
+        self.s3_client = S3Client._create_s3_client()
+        (
+            self.github_user_mapping_bucket_name,
+            self.github_user_mapping_key_name,
+        ) = GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH.split("/", 1)
+
+    # getter for the singleton
+    @classmethod
+    def singleton(cls):
+        """
+        Getter for the S3Client singleton
+        """
+        if cls._singleton is None:
+            cls._singleton = S3Client()
+        return cls._singleton
+
+    @staticmethod
+    def _create_s3_client():
+        # Encapsulates creating a boto3 client connection for S3 with a more user-friendly error case
+        try:
+            return boto3.client("s3")
+        except NoRegionError:
+            pass
+        # by raising the new error outside of the except clause, the ConfigurationError does not automatically contain
+        # the stack trace of the NoRegionError, which provides no extra value and clutters the console.
+        raise ConfigurationError(
+            "Configuration error: Please select a region, e.g. via"
+            " `AWS_DEFAULT_REGION=us-east-1`"
+        )
+
+    @memoize
+    def get_asana_domain_user_id_from_github_username(
+        self, github_username: str
+    ) -> Optional[str]:
+        """
+        Retrieves the Asana domain user-id associated with a specific GitHub user login, or None,
+        if no such association exists.
+        """
+        with closing(
+            self.s3_client.get_object(
+                Bucket=self.github_user_mapping_bucket_name,
+                Key=self.github_user_mapping_key_name,
+            )["Body"]
+        ) as stream:
+            github_identities_to_asana_gids = json.load(stream)
+
+        if github_username in github_identities_to_asana_gids:
+            logger.info(
+                "Successfully retrieved Asana domain user id from S3 for %s",
+                github_username,
+            )
+            return github_identities_to_asana_gids[github_username]
+        else:
+            return None
+
+
 def get_asana_id_from_github_node_id(gh_node_id: str) -> Optional[str]:
     """
     Using the singleton instance of DynamoDbClient, creating it if necessary:
@@ -200,18 +283,47 @@ def insert_github_node_to_asana_id_mapping(gh_node_id: str, asana_id: str):
 
 def get_asana_domain_user_id_from_github_handle(github_handle: str) -> Optional[str]:
     """
-    Using the singleton instance of DynamoDbClient, creating it if necessary:
+    Using the singleton instance of S3Client, creating it if necessary:
 
     Retrieves the Asana domain user-id associated with a specific GitHub user login, or None,
-    if no such association exists. User-id associations are created manually via an external process.
+    if no such association exists. User-id associations are created manually via an external
+    process.
+
+    If the S3 pathway fails, we fall back to the DynamoDb pathway.
     """
-    return DynamoDbClient.singleton().get_asana_domain_user_id_from_github_handle(
-        github_handle
-    )
+
+    def fallback_to_dynamo_pathway() -> Optional[str]:
+        dynamodb_returns = DynamoDbClient.singleton().DEPRECATED_get_asana_domain_user_id_from_github_handle(
+            github_handle
+        )
+        if dynamodb_returns is not None:
+            # we only want to emit a warning about the S3 pathway if the dynamoDB lookup returns
+            # something that's not null
+            logger.warning(
+                "S3 lookup failed to find the Asana domain user id for github handle %s. The DynamoDB table returned %s. Error: %s",
+                github_handle,
+                dynamodb_returns,
+                traceback.format_exc(),
+            )
+        return dynamodb_returns
+
+    try:
+        if user_id := S3Client.singleton().get_asana_domain_user_id_from_github_username(
+            github_handle
+        ):
+            return user_id
+        else:
+            return fallback_to_dynamo_pathway()
+    except Exception:
+        return fallback_to_dynamo_pathway()
 
 
-def get_all_user_items() -> List[dict]:
-    return DynamoDbClient.singleton().get_all_user_items()
+def DEPRECATED_get_all_user_items() -> List[dict]:
+    """
+    This function is marked as deprecated since it's only used by the `sync_users` Lambda function,
+    which we are planning to deprecate in favor of reading SGTM user info from S3 instead of DynamoDB.
+    """
+    return DynamoDbClient.singleton().DEPRECATED_get_all_user_items()
 
 
 def bulk_insert_github_node_to_asana_id_mapping(
@@ -227,12 +339,16 @@ def bulk_insert_github_node_to_asana_id_mapping(
     )
 
 
-def bulk_insert_github_handle_to_asana_user_id_mapping(
+def DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping(
     gh_and_asana_ids: List[Tuple[str, str]]
 ):
     """
+    This function is marked as deprecated since it's only used by the `sync_users` Lambda function,
+    which we are planning to deprecate in favor of reading SGTM user info from S3 instead of DynamoDB.
+
     Insert multiple mappings from github handle to Asana user ids.
     """
-    DynamoDbClient.singleton().bulk_insert_github_handle_to_asana_user_id_mapping(
+    # todo why/where lol
+    DynamoDbClient.singleton().DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping(
         gh_and_asana_ids
     )

--- a/src/sync_users/README.md
+++ b/src/sync_users/README.md
@@ -1,0 +1,1 @@
+# todo delete this entire lambda once we are successfully pulling users from S3 instead of Asana

--- a/src/sync_users/handler.py
+++ b/src/sync_users/handler.py
@@ -23,7 +23,7 @@ def handler(event: dict, context: dict) -> None:
     users_in_dynamodb = set(
         [
             SgtmUser.from_dynamodb_item(item)
-            for item in dynamodb_client.get_all_user_items()
+            for item in dynamodb_client.DEPRECATED_get_all_user_items()
         ]
     )
     logger.info("Found {} users in dynamodb".format(len(users_in_dynamodb)))
@@ -46,7 +46,7 @@ def handler(event: dict, context: dict) -> None:
 
     # Batch write the users
     if len(users_to_add) > 0:
-        dynamodb_client.bulk_insert_github_handle_to_asana_user_id_mapping(
+        dynamodb_client.DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping(
             [(u.github_handle, u.domain_user_id) for u in users_to_add]
         )
         logger.info("Done writing user mappings to DynamoDb")

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -68,6 +68,11 @@ variable "asana_users_project_id" {
   description = "Project ID that holds the tasks that map Github handles to Asana user ids"
 }
 
+variable "github_usernames_to_asana_gids_s3_path" {
+  description = "The S3 path, in the form bucket/key, to the .json file that maps Github usernames to email addresses associated with Asana users."
+  type        = string
+}
+
 variable "sgtm_feature__automerge_enabled" {
   type        = string
   description = "'true' if behavior to automerge pull requests with Github labels is enabled"
@@ -99,9 +104,9 @@ variable "sgtm_feature__followup_review_github_users" {
 }
 
 variable "sgtm_feature__check_rerun_threshold_hours" {
-  type = number
+  type        = number
   description = "Number of hours after which a check run should be rerequested. Must be combined with sgtm_feature__check_rerun_base_ref_names."
-  default = 0
+  default     = 0
 }
 
 variable "sgtm_feature__check_rerun_base_ref_names" {

--- a/test/dynamodb/test_client.py
+++ b/test/dynamodb/test_client.py
@@ -31,7 +31,9 @@ class DynamodbClientTest(MockDynamoDbTestCase):
 
     def test_bulk_insert_github_handle_to_asana_user_id_mapping(self):
         mappings = [("user1", "1"), ("user2", "2")]
-        dynamodb_client.bulk_insert_github_handle_to_asana_user_id_mapping(mappings)
+        dynamodb_client.DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping(
+            mappings
+        )
         self.assertEqual(
             dynamodb_client.get_asana_domain_user_id_from_github_handle("user1"),
             "1",
@@ -40,7 +42,7 @@ class DynamodbClientTest(MockDynamoDbTestCase):
             dynamodb_client.get_asana_domain_user_id_from_github_handle("user2"),
             "2",
         )
-        user_items = dynamodb_client.get_all_user_items()
+        user_items = dynamodb_client.DEPRECATED_get_all_user_items()
         self.assertEqual(len(list(user_items)), 2)
 
 

--- a/test/sync_users/test_handler.py
+++ b/test/sync_users/test_handler.py
@@ -12,8 +12,10 @@ USER_ID_KEY = dynamodb_client.DynamoDbClient.USER_ID_KEY
 
 
 @patch.object(asana_client, "find_all_tasks_for_project")
-@patch.object(dynamodb_client, "bulk_insert_github_handle_to_asana_user_id_mapping")
-@patch.object(dynamodb_client, "get_all_user_items")
+@patch.object(
+    dynamodb_client, "DEPRECATED_bulk_insert_github_handle_to_asana_user_id_mapping"
+)
+@patch.object(dynamodb_client, "DEPRECATED_get_all_user_items")
 class TestHandler(unittest.TestCase):
     def test_no_users_to_sync__all_already_synced(
         self, get_all_user_items_mock, bulk_insert_mock, find_tasks_mock


### PR DESCRIPTION
### Summary

We'd like to stop maintaining the [Asanas in Github Asana project](https://app.asana.com/0/64201726605125/64201726605125), which is currently kept up-to-date by a lambda that Infrasec maintains. SGTM is the final remaining dependency on this project. This PR adds code for SGTM to read from S3 to determine which asana user a github username corresponds to. If reading from the S3 file fails for any reason, SGTM will revert to the existing DynamoDB table, which is still being synced from the Asanas in Github project.

I'll be monitoring SGTM logs  [here](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fsgtm/log-events$3FfilterPattern$3D$26start$3D-3600000) to ensure that there's no warnings emitted, and to confirm that all usernames are being converted to gids correctly. Once it's been ~1 business day of things working as expected, I'll make a follow-up PR to remove the backup pathway, and then another one to delete all the unneeded infra :)  

Asana tasks:
https://app.asana.com/0/1149418478823393/1204738744867777/f


Relevant deployment: 

CC: @suzyng83209 @prebeta @vn6 @mattbryant-asana @skeggse

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/165



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207061300950944)