### PR TITLE
[SGTM Error handling] log warnings when no followers are found and only add followers if there are some

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Callable, Match, Optional, List, Dict, Set
 from src.dynamodb import client as dynamodb_client
 from src.asana import logic as asana_logic
-from src.config import SGTM_FEATURE__ALLOW_PERSISTENT_TASK_ASSIGNEE
+from src.config import GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH
 from src.github.models import (
     Comment,
     PullRequest,
@@ -484,7 +484,7 @@ def task_followers_from_pull_request(pull_request: PullRequest) -> List[str]:
 
 
 def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
-    return [
+    followers = [
         asana_user_id
         for github_handle in gh_handles
         if (
@@ -494,6 +494,11 @@ def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
         )
         is not None
     ]
+    if not len(followers):
+        logger.warn(
+            f"No followers found for {gh_handles}. This list likely includes bots or users that are not in your {GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH}. Consider adding them to silence this warning."
+        )
+    return followers
 
 
 def _wrap_in_tag(

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -496,7 +496,7 @@ def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
     ]
     if not len(followers):
         logger.warn(
-            f"No followers found for {gh_handles}. This list likely includes bots or users that are not in your {GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH}. Consider adding them to silence this warning."
+            f"No asana followers found for github users {gh_handles}. This list likely includes bots or users that are not in your {GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH}. Consider adding them to silence this warning."
         )
     return followers
 

--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -494,7 +494,7 @@ def _task_followers_from_gh_handles(gh_handles: List[str]) -> List[str]:
         )
         is not None
     ]
-    if not len(followers):
+    if len(followers) == 0:
         logger.warn(
             f"No asana followers found for github users {gh_handles}. This list likely includes bots or users that are not in your {GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH}. Consider adding them to silence this warning."
         )

--- a/src/config.py
+++ b/src/config.py
@@ -15,6 +15,7 @@ GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH = os.getenv(
     "GITHUB_USERNAMES_TO_ASANA_GIDS_S3_PATH",
 )
 
+
 # Feature flags
 def is_feature_flag_enabled(flag_name: str) -> bool:
     return os.getenv(flag_name) == "true"

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -794,7 +794,8 @@ class TestTaskFollowersFromPullRequest(BaseClass):
         followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    def test_non_asana_user_is_not_a_follower(self):
+    @patch("src.logger.warn")
+    def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
         )
@@ -817,6 +818,7 @@ class TestTaskFollowersFromPullRequest(BaseClass):
         )
         followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertEqual(0, len(followers))
+        mock_warn.assert_called_once()
 
 
 class TestTaskFollowersFromReview(BaseClass):
@@ -837,7 +839,8 @@ class TestTaskFollowersFromReview(BaseClass):
         followers = src.asana.helpers.task_followers_from_review(review)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    def test_non_asana_user_is_not_a_follower(self):
+    @patch("src.logger.warn")
+    def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
         )
@@ -849,6 +852,7 @@ class TestTaskFollowersFromReview(BaseClass):
         )
         followers = src.asana.helpers.task_followers_from_review(review)
         self.assertEqual(0, len(followers))
+        mock_warn.assert_called_once()
 
 
 class TestTaskFollowersFromComment(BaseClass):
@@ -868,7 +872,8 @@ class TestTaskFollowersFromComment(BaseClass):
         followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    def test_non_asana_user_is_not_a_follower(self):
+    @patch("src.logger.warn")
+    def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
         )
@@ -880,6 +885,7 @@ class TestTaskFollowersFromComment(BaseClass):
         )
         followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertEqual(0, len(followers))
+        mock_warn.assert_called_once()
 
 
 class TestExtractsInconsistentFieldsFromPullRequest(BaseClass):

--- a/test/asana/helpers/test_extract_task_fields_from_pull_request.py
+++ b/test/asana/helpers/test_extract_task_fields_from_pull_request.py
@@ -794,7 +794,7 @@ class TestTaskFollowersFromPullRequest(BaseClass):
         followers = src.asana.helpers.task_followers_from_pull_request(pull_request)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    @patch("src.logger.warn")
+    @patch("src.logger.logger.warn")
     def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
@@ -839,7 +839,7 @@ class TestTaskFollowersFromReview(BaseClass):
         followers = src.asana.helpers.task_followers_from_review(review)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    @patch("src.logger.warn")
+    @patch("src.logger.logger.warn")
     def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")
@@ -872,7 +872,7 @@ class TestTaskFollowersFromComment(BaseClass):
         followers = src.asana.helpers.task_followers_from_comment(comment)
         self.assertIn("TEST_USER_ASANA_DOMAIN_USER_ID", followers)
 
-    @patch("src.logger.warn")
+    @patch("src.logger.logger.warn")
     def test_non_asana_user_is_not_a_follower(self, mock_warn):
         unknown_github_user = build(
             builder.user("github_unknown_user_login", "GITHUB_UNKNOWN_USER_NAME")


### PR DESCRIPTION
### Summary

- Based on people's usage of github and following changes in #166, we actually expect that some github handles won't convert to asana gids.
- as a result, we can frequently pass an empty list to `AsanaClient.add_followers`. Instead of try-catching and logging errors, we just don't do anything if there are no followers to add and log a warning to consider adding these missing users to the s3 file

Asana tasks:
https://app.asana.com/0/1200740774079340/1206916572348059/f


Relevant deployment: 

CC: @vn6 @prebeta @suzyng83209 @michael-huang87

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/175



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207201022869976)