### PR TITLE
[SGTM Dynamodb Locks] increase lock timeout to 60s

### DIFF
--- a/src/dynamodb/lock.py
+++ b/src/dynamodb/lock.py
@@ -21,7 +21,7 @@ lock_client = DynamoDBLockClient(
 
 @contextmanager
 def dynamodb_lock(
-    lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=45)
+    lock_name: str, retry_timeout: Optional[timedelta] = timedelta(seconds=60)
 ):
     lock = lock_client.acquire_lock(
         lock_name, sort_key=lock_name, retry_timeout=retry_timeout


### PR DESCRIPTION
### Summary

- a lot of lambda invocations just waste time waiting for the lock and inevitably early exiting due to the short lock timeout.
- we temporarily increase this to reduce error rates
- eventually we want to reduce the number of bottlenecks during lambda invocation because this change will increase our average invocation length and cost us $$$

Asana tasks:
https://app.asana.com/0/1200740774079340/1207209762057512/f


Relevant deployment: 

CC: @vn6 @prebeta @suzyng83209 @michael-huang87 @harshita-gupta

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/177



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207210254110004)