### PR TITLE
[SGTM refactor] simplify pull_request label logic

### DIFF
--- a/src/asana/logic.py
+++ b/src/asana/logic.py
@@ -1,5 +1,4 @@
 from src.github.models import PullRequest
-from src.github.helpers import pull_request_has_label
 from enum import Enum, unique
 from src.config import (
     SGTM_FEATURE__AUTOCOMPLETE_ENABLED,
@@ -21,13 +20,11 @@ def should_autocomplete_tasks_on_merge(pull_request: PullRequest) -> bool:
     return (
         SGTM_FEATURE__AUTOCOMPLETE_ENABLED
         and pull_request.merged()
-        and pull_request_has_label(
-            pull_request, AutocompleteLabel.COMPLETE_ON_MERGE.value
-        )
+        and pull_request.has_label(AutocompleteLabel.COMPLETE_ON_MERGE.value)
     )
 
 
 def should_set_task_owner_to_pr_author(pull_request: PullRequest) -> bool:
-    return SGTM_FEATURE__ALLOW_PERSISTENT_TASK_ASSIGNEE and pull_request_has_label(
-        pull_request, TaskAssigneeLabel.PERSISTENT.value
+    return SGTM_FEATURE__ALLOW_PERSISTENT_TASK_ASSIGNEE and pull_request.has_label(
+        TaskAssigneeLabel.PERSISTENT.value
     )

--- a/src/github/helpers.py
+++ b/src/github/helpers.py
@@ -1,6 +1,0 @@
-from src.github.models import PullRequest
-
-
-def pull_request_has_label(pull_request: PullRequest, label: str) -> bool:
-    label_names = map(lambda label: label.name(), pull_request.labels())
-    return label in label_names

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -214,5 +214,11 @@ class PullRequest(object):
     def labels(self) -> List[Label]:
         return [Label(label) for label in self._raw["labels"]["nodes"]]
 
+    def has_label(self, label: str) -> bool:
+        for label in self.labels():
+            if label.name() == label:
+                return True
+        return False
+
     def base_ref_name(self) -> str:
         return self._raw["baseRefName"]

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -1,11 +1,9 @@
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import patch
 import src.github.logic as github_logic
-from src.github.models import Commit, ReviewState, PullRequest, MergeableState
+from src.github.models import Commit, ReviewState, MergeableState
 from test.impl.builders import builder, build
-import src.github.controller as github_controller
 import src.github.client as github_client
-from src.github.helpers import pull_request_has_label
 
 
 @patch.object(github_client, "merge_pull_request")
@@ -796,22 +794,6 @@ class TestMaybeRerunStaleRequiredChecks(unittest.TestCase):
             github_logic.maybe_rerun_stale_checks_on_approved_pull_request(pull_request)
         )
         mock_rerequest_check_run.assert_not_called()
-
-
-class TestPullRequestHasLabel(unittest.TestCase):
-    def test_pull_request_with_label(self):
-        label_name = "test label"
-        pull_request = build(
-            builder.pull_request().label(builder.label().name(label_name))
-        )
-
-        self.assertTrue(github_logic.pull_request_has_label(pull_request, label_name))
-
-    def test_pull_request_without_label(self):
-        label_name = "test label"
-        pull_request = build(builder.pull_request())
-
-        self.assertFalse(github_logic.pull_request_has_label(pull_request, label_name))
 
 
 @patch.object(github_client, "edit_pr_title")


### PR DESCRIPTION
### Summary

- flyby fix while moving queries in and out of the dynamodb locks
- this should increase the granularity of logs and deletes a very unnecessary helper.
- by adding this logic to the model itself, it makes it impossible to test. However, I don't think this test added much

Asana tasks:


Relevant deployment: 

CC: @prebeta

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/178



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207215320082082)