### PR TITLE
[SGTM performance] Modify comment webhook to be have fewer mutations

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -91,7 +91,7 @@ def upsert_github_comment_to_task(comment: Comment, task_id: str):
         asana_client.update_comment(
             asana_comment_id, asana_helpers.asana_comment_from_github_comment(comment)
         )
-    
+
     # Optionally add followers from the comment body
     followers = asana_helpers.task_followers_from_comment(comment)
     if len(followers) > 0:

--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -91,6 +91,11 @@ def upsert_github_comment_to_task(comment: Comment, task_id: str):
         asana_client.update_comment(
             asana_comment_id, asana_helpers.asana_comment_from_github_comment(comment)
         )
+    
+    # Optionally add followers from the comment body
+    followers = asana_helpers.task_followers_from_comment(comment)
+    if len(followers) > 0:
+        asana_client.add_followers(task_id, followers)
 
 
 def upsert_github_review_to_task(review: Review, task_id: str):

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -62,10 +62,7 @@ def upsert_review(pull_request: PullRequest, review: Review):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id is None:
-        logger.info(
-            f"Task not found for pull request {pull_request_id}. Running a full sync!"
-        )
-        # TODO: Full sync
+        logger.error(f"Task not found for pull request {pull_request_id}. Exiting!")
     else:
         logger.info(
             f"Found task id {task_id} for pull_request {pull_request_id}. Adding review"

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -53,15 +53,11 @@ def upsert_comment(pull_request: PullRequest, comment: Comment):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id is None:
-        logger.info(
-            f"Task not found for pull request {pull_request_id}. Running a full sync!"
+        logger.error(
+            f"Task not found for pull request {pull_request_id}. Exiting!"
         )
-        # TODO: Full sync
     else:
         asana_controller.upsert_github_comment_to_task(comment, task_id)
-        asana_controller.update_task(
-            pull_request, task_id, asana_helpers.task_followers_from_comment(comment)
-        )
 
 
 def upsert_review(pull_request: PullRequest, review: Review):

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -53,9 +53,7 @@ def upsert_comment(pull_request: PullRequest, comment: Comment):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id is None:
-        logger.error(
-            f"Task not found for pull request {pull_request_id}. Exiting!"
-        )
+        logger.error(f"Task not found for pull request {pull_request_id}. Exiting!")
     else:
         asana_controller.upsert_github_comment_to_task(comment, task_id)
 

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -53,7 +53,7 @@ def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
         return HttpResponse("200")
 
     error_text = f"Unknown action for issue_comment: {action}"
-    logger.info(error_text)
+    logger.error(error_text)
     return HttpResponse("400", error_text)
 
 

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -34,7 +34,7 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
 def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
     action, issue, comment = itemgetter("action", "issue", "comment")(payload)
 
-    issue_id = issue["node_id"] # issue_id can be pull_request_id
+    issue_id = issue["node_id"]  # issue_id can be pull_request_id
     comment_id = comment["node_id"]
     logger.info(f"issue: {issue_id}, comment: {comment_id}")
 
@@ -45,7 +45,7 @@ def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
             )
             github_controller.upsert_comment(pull_request, comment)
         return HttpResponse("200")
-        
+
     if action == "deleted":
         logger.info(f"Deleting comment {comment_id}")
         with dynamodb_lock(comment_id):

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -127,7 +127,7 @@ def _handle_pull_request_review_comment(payload: dict):
         with dynamodb_lock(comment_id):
             github_controller.delete_comment(comment_id)
         return _handle_pull_request_webhook(payload)
-    
+
     with dynamodb_lock(review.id()):
         github_controller.upsert_review(pull_request, review)
     return HttpResponse("200")

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -113,7 +113,7 @@ def _handle_pull_request_review_comment(payload: dict):
     if action == "deleted":
         # This is NOT the node_id, but is a numeric string (the databaseId field).
         review_database_id = payload["comment"]["pull_request_review_id"]
-        review = graphql_client.get_review_for_database_id(
+        review: Optional[Review] = graphql_client.get_review_for_database_id(
             pull_request_id, review_database_id
         )
         if review is None:

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -107,7 +107,7 @@ def _handle_pull_request_review_comment(payload: dict):
             )
         review = Review.from_comment(comment)
         with dynamodb_lock(review.id()):
-            github_controller.upsert_review(pull_request, comment)
+            github_controller.upsert_review(pull_request, review)
         return HttpResponse("200")
 
     if action == "deleted":

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -113,6 +113,7 @@ class TestUpsertGithubReviewToTask(BaseClass):
 
 
 @patch("src.asana.helpers.asana_comment_from_github_comment")
+@patch("src.asana.helpers.task_followers_from_comment")
 @patch("src.dynamodb.client.insert_github_node_to_asana_id_mapping")
 class TestUpsertGithubCommentToTask(BaseClass):
     COMMENT_ID = "12345"
@@ -132,9 +133,11 @@ class TestUpsertGithubCommentToTask(BaseClass):
         create_attachments_mock,
         add_comment_mock,
         insert_github_node_to_asana_id_mapping_mock,
+        task_followers_from_comment_mock,
         asana_comment_from_github_comment_mock,
     ):
         asana_comment_from_github_comment_mock.return_value = self.ASANA_COMMENT_BODY
+        task_followers_from_comment_mock.return_value = []
         comment = self._mock_comment(self.COMMENT_ID)
 
         controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
@@ -153,12 +156,14 @@ class TestUpsertGithubCommentToTask(BaseClass):
         get_asana_id_from_github_node_id_mock,
         update_comment_mock,
         insert_github_node_to_asana_id_mapping_mock,
+        task_followers_from_comment_mock,
         asana_comment_from_github_comment_mock,
     ):
         get_asana_id_from_github_node_id_mock.return_value = self.ASANA_COMMENT_ID
         asana_comment_from_github_comment_mock.return_value = (
             "<body>Here's an updated comment</body>"
         )
+        task_followers_from_comment_mock.return_value = []
         comment = self._mock_comment(self.COMMENT_ID)
 
         controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -112,7 +112,7 @@ class TestUpsertGithubReviewToTask(BaseClass):
         add_comment.assert_not_called()
 
 
-@patch("src.asana.helpers.asana_comment_from_github_review")
+@patch("src.asana.helpers.asana_comment_from_github_comment")
 @patch("src.dynamodb.client.insert_github_node_to_asana_id_mapping")
 class TestUpsertGithubCommentToTask(BaseClass):
     COMMENT_ID = "12345"
@@ -132,9 +132,9 @@ class TestUpsertGithubCommentToTask(BaseClass):
         create_attachments_mock,
         add_comment_mock,
         insert_github_node_to_asana_id_mapping_mock,
-        asana_comment_from_github_review_mock,
+        asana_comment_from_github_comment_mock,
     ):
-        asana_comment_from_github_review_mock.return_value = self.ASANA_COMMENT_BODY
+        asana_comment_from_github_comment_mock.return_value = self.ASANA_COMMENT_BODY
         comment = self._mock_comment(self.COMMENT_ID)
 
         controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
@@ -153,10 +153,10 @@ class TestUpsertGithubCommentToTask(BaseClass):
         get_asana_id_from_github_node_id_mock,
         update_comment_mock,
         insert_github_node_to_asana_id_mapping_mock,
-        asana_comment_from_github_review_mock,
+        asana_comment_from_github_comment_mock,
     ):
         get_asana_id_from_github_node_id_mock.return_value = self.ASANA_COMMENT_ID
-        asana_comment_from_github_review_mock.return_value = (
+        asana_comment_from_github_comment_mock.return_value = (
             "<body>Here's an updated comment</body>"
         )
         comment = self._mock_comment(self.COMMENT_ID)

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -136,8 +136,10 @@ class TestUpsertGithubCommentToTask(BaseClass):
         task_followers_from_comment_mock,
         asana_comment_from_github_comment_mock,
     ):
+        add_comment_mock.return_value = self.ASANA_COMMENT_ID
         asana_comment_from_github_comment_mock.return_value = self.ASANA_COMMENT_BODY
         task_followers_from_comment_mock.return_value = []
+
         comment = self._mock_comment(self.COMMENT_ID)
 
         controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
@@ -159,17 +161,17 @@ class TestUpsertGithubCommentToTask(BaseClass):
         task_followers_from_comment_mock,
         asana_comment_from_github_comment_mock,
     ):
-        get_asana_id_from_github_node_id_mock.return_value = self.ASANA_COMMENT_ID
         asana_comment_from_github_comment_mock.return_value = (
             "<body>Here's an updated comment</body>"
         )
+        get_asana_id_from_github_node_id_mock.return_value = self.ASANA_COMMENT_ID
         task_followers_from_comment_mock.return_value = []
         comment = self._mock_comment(self.COMMENT_ID)
 
         controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
 
         update_comment_mock.assert_called_once_with(
-            self.ASANA_COMMENT_ID, self.ASANA_COMMENT_BODY
+            self.ASANA_COMMENT_ID, "<body>Here's an updated comment</body>"
         )
         insert_github_node_to_asana_id_mapping_mock.assert_not_called()
 

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -112,6 +112,63 @@ class TestUpsertGithubReviewToTask(BaseClass):
         add_comment.assert_not_called()
 
 
+@patch("src.asana.helpers.asana_comment_from_github_review")
+@patch("src.dynamodb.client.insert_github_node_to_asana_id_mapping")
+class TestUpsertGithubCommentToTask(BaseClass):
+    COMMENT_ID = "12345"
+    ASANA_COMMENT_ID = "56789"
+    ASANA_TASK_ID = "abcde"
+    ASANA_COMMENT_BODY = "<body>Here's a comment</body>"
+
+    def _mock_comment(self, id):
+        return MagicMock(spec=Comment, id=MagicMock(return_value=id))
+
+    @patch("src.asana.client.add_comment")
+    @patch("src.asana.helpers.create_attachments")
+    @patch("src.dynamodb.client.get_asana_id_from_github_node_id", return_value=None)
+    def test_add_new_comment_if_not_found(
+        self,
+        get_asana_id_from_github_node_id_mock,
+        create_attachments_mock,
+        add_comment_mock,
+        insert_github_node_to_asana_id_mapping_mock,
+        asana_comment_from_github_review_mock,
+    ):
+        asana_comment_from_github_review_mock.return_value = self.ASANA_COMMENT_BODY
+        comment = self._mock_comment(self.COMMENT_ID)
+
+        controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
+
+        add_comment_mock.assert_called_once_with(
+            self.ASANA_TASK_ID, self.ASANA_COMMENT_BODY
+        )
+        insert_github_node_to_asana_id_mapping_mock.assert_called_once_with(
+            self.COMMENT_ID, self.ASANA_COMMENT_ID
+        )
+
+    @patch("src.asana.client.update_comment")
+    @patch("src.dynamodb.client.get_asana_id_from_github_node_id")
+    def test_updated_comment(
+        self,
+        get_asana_id_from_github_node_id_mock,
+        update_comment_mock,
+        insert_github_node_to_asana_id_mapping_mock,
+        asana_comment_from_github_review_mock,
+    ):
+        get_asana_id_from_github_node_id_mock.return_value = self.ASANA_COMMENT_ID
+        asana_comment_from_github_review_mock.return_value = (
+            "<body>Here's an updated comment</body>"
+        )
+        comment = self._mock_comment(self.COMMENT_ID)
+
+        controller.upsert_github_comment_to_task(comment, self.ASANA_TASK_ID)
+
+        update_comment_mock.assert_called_once_with(
+            self.ASANA_COMMENT_ID, self.ASANA_COMMENT_BODY
+        )
+        insert_github_node_to_asana_id_mapping_mock.assert_not_called()
+
+
 class TestNewDueOnOrNone(BaseClass):
     def test_new_assignee_due_on_change(self):
         task = {"assignee": {"gid": "123"}, "due_on": "2010-01-01"}

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -78,12 +78,10 @@ class GithubControllerTest(MockDynamoDbTestCase):
             "original body\s*Pull Request synchronized with \[Asana task\]",
         )
 
-    @patch.object(asana_controller, "update_task")
     @patch.object(asana_controller, "upsert_github_comment_to_task")
     def test_upsert_comment_when_task_id_already_found_in_dynamodb(
         self,
         add_comment_mock,
-        update_task_mock,
         _get_asana_domain_id_mock,
     ):
         # If the task id is found in dynamodb, then we just update (don't
@@ -100,9 +98,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         github_controller.upsert_comment(pull_request, comment)
 
         add_comment_mock.assert_called_with(comment, existing_task_id)
-        update_task_mock.assert_called_with(pull_request, existing_task_id, ANY)
 
-    @patch.object(asana_controller, "update_task")
     @patch.object(asana_controller, "upsert_github_comment_to_task")
     def test_upsert_comment_when_task_id_not_found_in_dynamodb(
         self,
@@ -114,7 +110,6 @@ class GithubControllerTest(MockDynamoDbTestCase):
         comment = builder.comment().build()
 
         github_controller.upsert_comment(pull_request, comment)
-        # TODO: Test that a full sync was performed
 
     @patch.object(github_client, "set_pull_request_assignee")
     def test_assign_pull_request_to_author(

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -103,7 +103,6 @@ class GithubControllerTest(MockDynamoDbTestCase):
     def test_upsert_comment_when_task_id_not_found_in_dynamodb(
         self,
         add_comment_mock,
-        update_task_mock,
         _get_asana_domain_id_mock,
     ):
         pull_request = builder.pull_request().build()

--- a/test/github/test_webhook.py
+++ b/test/github/test_webhook.py
@@ -127,7 +127,7 @@ class TestHandlePullRequestReviewComment(BaseClass):
 
         webhook._handle_pull_request_review_comment(self.payload)
 
-        get_pull_request.assert_called_once_with(self.PULL_REQUEST_NODE_ID)
+        get_pull_request.assert_called_with(self.PULL_REQUEST_NODE_ID)
         upsert_pull_request.assert_called_once_with(get_pull_request.return_value)
         upsert_review.assert_not_called()
         get_review_for_database_id.assert_called_once_with(

--- a/test/github/test_webhook.py
+++ b/test/github/test_webhook.py
@@ -108,6 +108,7 @@ class TestHandlePullRequestReviewComment(BaseClass):
         )
         delete_comment.assert_not_called()
 
+    @patch("src.github.controller.upsert_pull_request")
     @patch(
         "src.github.graphql.client.get_pull_request",
         return_value=MagicMock(spec=PullRequest),
@@ -117,6 +118,7 @@ class TestHandlePullRequestReviewComment(BaseClass):
         self,
         get_review_for_database_id,
         get_pull_request,
+        upsert_pull_request,
         upsert_review,
         delete_comment,
         lock,
@@ -126,6 +128,7 @@ class TestHandlePullRequestReviewComment(BaseClass):
         webhook._handle_pull_request_review_comment(self.payload)
 
         get_pull_request.assert_called_once_with(self.PULL_REQUEST_NODE_ID)
+        upsert_pull_request.assert_called_once_with(get_pull_request.return_value)
         upsert_review.assert_not_called()
         get_review_for_database_id.assert_called_once_with(
             self.PULL_REQUEST_NODE_ID, self.PULL_REQUEST_REVIEW_ID


### PR DESCRIPTION
### Summary

- issue comments have 3 supported actions: created, edit, and deleted. We lock on the issue id (pull request id) and to a full `update_task` on the pull_request body when we don't need to
- instead of full updating, only upsert the comment and add followers if there are any
- instead of locking on the pr id, lock on the comment id

Asana tasks:
https://app.asana.com/0/1200740774079340/1207209762057512/f]
https://app.asana.com/0/1200740774079340/1207209762057512/f


Relevant deployment: 

CC: @prebeta @suzyng83209 @vn6 @michael-huang87 @harshita-gupta

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/179



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207215638657145)