### PR TITLE
[SGTM dynamodb perf] remove excess get

### DIFF
--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -16,7 +16,6 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
     pull_request_id = payload["pull_request"]["node_id"]
     pull_request = graphql_client.get_pull_request(pull_request_id)
     with dynamodb_lock(pull_request_id):
-        pull_request = graphql_client.get_pull_request(pull_request_id)
         # maybe rerun stale checks on approved PR before attempting to automerge
         did_rerun_stale_required_checks = (
             github_logic.maybe_rerun_stale_checks_on_approved_pull_request(pull_request)


### PR DESCRIPTION
### Summary

- doing extra work in the dynamodb lock increases the possibility of a backlog building up for a given node
- there was an extra query for pull requests when we already query for the pull request object 2 lines above

Asana tasks:
https://app.asana.com/0/1200740774079340/1207209762057512/f


Relevant deployment: 

CC: @prebeta @suzyng83209 @vn6 @michael-huang87

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/180



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207233792817909)