### PR TITLE
[SGTM bugs] move querying back under lock to reduce likelihood of duplicate syncs

### DIFF
--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -114,7 +114,7 @@ def _handle_pull_request_review_comment(payload: dict):
         with dynamodb_lock(pull_request_id):
             # This is NOT the node_id, but is a numeric string (the databaseId field).
             review_database_id = payload["comment"]["pull_request_review_id"]
-            maybe_review: Optional[Review] = graphql_client.get_review_for_database_id(
+            maybe_review = graphql_client.get_review_for_database_id(
                 pull_request_id, review_database_id
             )
             if maybe_review is None:

--- a/test/github/test_webhook.py
+++ b/test/github/test_webhook.py
@@ -109,15 +109,10 @@ class TestHandlePullRequestReviewComment(BaseClass):
         delete_comment.assert_not_called()
 
     @patch("src.github.controller.upsert_pull_request")
-    @patch(
-        "src.github.graphql.client.get_pull_request",
-        return_value=MagicMock(spec=PullRequest),
-    )
     @patch("src.github.graphql.client.get_review_for_database_id", return_value=None)
     def test_comment_deletion_when_review_not_found(
         self,
         get_review_for_database_id,
-        get_pull_request,
         upsert_pull_request,
         upsert_review,
         delete_comment,
@@ -127,8 +122,6 @@ class TestHandlePullRequestReviewComment(BaseClass):
 
         webhook._handle_pull_request_review_comment(self.payload)
 
-        get_pull_request.assert_called_with(self.PULL_REQUEST_NODE_ID)
-        upsert_pull_request.assert_called_once_with(get_pull_request.return_value)
         upsert_review.assert_not_called()
         get_review_for_database_id.assert_called_once_with(
             self.PULL_REQUEST_NODE_ID, self.PULL_REQUEST_REVIEW_ID


### PR DESCRIPTION
### Summary

- moves a few queries back under the lock so that the state is fresh

Asana tasks:
https://app.asana.com/0/1149418478823393/1207262750511241/f


Relevant deployment: 

CC: @prebeta @suzyng83209 @vn6 @michael-huang87

### Test Plan



### Risks



Pull Request: https://github.com/Asana/SGTM/pull/181



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207262952184692)