### PR TITLE
[SGTM bugs] let due_on handle nulls and add more test

### DIFF
--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -39,7 +39,7 @@ def update_task(
     )
     if new_due_on is not None:
         update_task_fields["due_on"] = new_due_on
-        
+
     logger.info(f"Updating task {task_id} with fields: {update_task_fields}")
     asana_client.update_task(task_id, update_task_fields)
     # Add followers is optional because Asana should automatically add followers
@@ -53,7 +53,7 @@ def update_task(
 def _new_due_on_or_none(task: dict, update_task_fields: dict) -> Optional[str]:
     today = asana_helpers.today_str()
 
-    if task["due_on"] and task["due_on"] >= today:
+    if task.get("due_on") and task.get("due_on") >= today:
         # don't update due dates that aren't stale
         return None
     elif (task.get("assignee") or {}).get("gid") != update_task_fields.get("assignee"):

--- a/src/asana/controller.py
+++ b/src/asana/controller.py
@@ -31,7 +31,6 @@ def update_task(
     update_task_fields = asana_helpers.extract_task_fields_from_pull_request(
         pull_request
     )
-    logger.info(f"Updating task {task_id} with fields: {update_task_fields}")
     task = asana_client.get_task(task_id)
     new_due_on = (
         asana_helpers.today_str()
@@ -40,6 +39,8 @@ def update_task(
     )
     if new_due_on is not None:
         update_task_fields["due_on"] = new_due_on
+        
+    logger.info(f"Updating task {task_id} with fields: {update_task_fields}")
     asana_client.update_task(task_id, update_task_fields)
     # Add followers is optional because Asana should automatically add followers
     # if the body contains well-formatted data-asana-gid fields. Also bots can sometimes create comments,
@@ -52,7 +53,7 @@ def update_task(
 def _new_due_on_or_none(task: dict, update_task_fields: dict) -> Optional[str]:
     today = asana_helpers.today_str()
 
-    if task["due_on"] >= today:
+    if task["due_on"] and task["due_on"] >= today:
         # don't update due dates that aren't stale
         return None
     elif (task.get("assignee") or {}).get("gid") != update_task_fields.get("assignee"):

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -203,6 +203,17 @@ class TestNewDueOnOrNone(BaseClass):
         update_task_fields = {"assignee": assignee_gid}
         self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), None)
 
+    def test_no_assignee(self):
+        task = {"assignee": None, "due_on": "2010-01-01"}
+        update_task_fields = {"assignee": "123"}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), datetime.now().strftime("%Y-%m-%d"))
+
+    def test_null_due_on(self):
+        assignee_gid = "123"
+        task = {"assignee": {"gid": assignee_gid}, "due_on": None}
+        update_task_fields = {"assignee": assignee_gid}
+        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), None)
+
 
 @patch("src.asana.client.complete_task")
 @patch("src.asana.helpers.get_linked_task_ids")

--- a/test/asana/test_controller.py
+++ b/test/asana/test_controller.py
@@ -206,7 +206,10 @@ class TestNewDueOnOrNone(BaseClass):
     def test_no_assignee(self):
         task = {"assignee": None, "due_on": "2010-01-01"}
         update_task_fields = {"assignee": "123"}
-        self.assertEqual(controller._new_due_on_or_none(task, update_task_fields), datetime.now().strftime("%Y-%m-%d"))
+        self.assertEqual(
+            controller._new_due_on_or_none(task, update_task_fields),
+            datetime.now().strftime("%Y-%m-%d"),
+        )
 
     def test_null_due_on(self):
         assignee_gid = "123"


### PR DESCRIPTION
### Summary

- Occassionally seeing errors of the type: 
```
  File "/var/task/src/handler.py", line 25, in handle_github_webhook
    http_response = github_webhook.handle_github_webhook(event_type, github_event)
  File "/var/task/src/github/webhook.py", line 195, in handle_github_webhook
    return _events_map[event_type](payload)
  File "/var/task/src/github/webhook.py", line 167, in _handle_check_suite_webhook
    github_controller.upsert_pull_request(pull_request)
  File "/var/task/src/github/controller.py", line 30, in upsert_pull_request
    asana_controller.update_task(
  File "/var/task/src/asana/controller.py", line 39, in update_task
    else _new_due_on_or_none(task, update_task_fields)
  File "/var/task/src/asana/controller.py", line 55, in _new_due_on_or_none
    if task["due_on"] >= today:
TypeError: '>=' not supported between instances of 'NoneType' and 'str'
```
- this just adds a null check. This happens if the due date is purposefully removed (someone decides they won't follow up with the PR for a long time)

Asana tasks:


Relevant deployment: 

CC: @prebeta @michael-huang87 @suzyng83209 @vn6

### Test Plan

- tests pass

### Risks



Pull Request: https://github.com/Asana/SGTM/pull/182
