### PR TITLE
[SGTM requeue events] add requeue handlers when no task found or comment approval

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -130,7 +130,7 @@ def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     project_id = dynamodb_client.get_asana_id_from_github_node_id(repository_id)
 
     if project_id is None:
-        logger.error(f"Task not found for pull request {pull_request.id()}.")
+        logger.error(f"Project not found for repo {repository_id}.")
         return {}
     else:
         custom_field_map = {

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -122,9 +122,6 @@ def _handle_pull_request_review_comment(payload: dict):
                 pull_request_id, review_database_id
             )
             if maybe_review is None:
-                # If a pull_request_review has only one comment that is deleted,
-                # the review is deleted. This can change the approval status of the PR
-                # so we need to handle this like a PR webhook.
                 github_controller.delete_comment(comment_id)
             else:
                 pull_request = graphql_client.get_pull_request(pull_request_id)

--- a/terraform/sgtm-cluster/api_gateway_sqs.tf
+++ b/terraform/sgtm-cluster/api_gateway_sqs.tf
@@ -58,6 +58,7 @@ resource "aws_sqs_queue" "sgtm-webhooks-queue-fifo" {
 resource "aws_lambda_event_source_mapping" "sgtm-sqs-source" {
   event_source_arn = aws_sqs_queue.sgtm-webhooks-queue-fifo.arn
   function_name    = aws_lambda_function.sgtm.function_name
+  batch_size       = 1
 }
 
 resource "aws_lambda_permission" "lambda_permission_for_sgtm_rest_api" {

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -137,7 +137,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
 
         github_controller.upsert_comment(pull_request, comment)
         add_comment_mock.assert_not_called()
-        queue_mock.assert_called_with(pull_request.id())    
+        queue_mock.assert_called_with(pull_request.id())
 
     @patch.object(github_client, "set_pull_request_assignee")
     def test_assign_pull_request_to_author(

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -141,7 +141,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
 
     @patch.object(github_client, "set_pull_request_assignee")
     def test_assign_pull_request_to_author(
-        self, set_pr_assignee_mock, _ge5t_asana_domain_id_mock
+        self, set_pr_assignee_mock, _get_asana_domain_id_mock
     ):
         user = builder.user().login("the_author").name("dont-care")
         pull_request = builder.pull_request().author(user).build()

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -65,11 +65,13 @@ class TestSQSRequeue(MockSQSTestCase):
                     },
                     "body": json.dumps(WEBHOOK_BODY_TEMPLATE),
                 },
-                context={}
+                context={},
             )
         self.assertEqual(response["statusCode"], "500")
 
-        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get("Messages", [])
+        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get(
+            "Messages", []
+        )
 
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0]["Body"], json.dumps(WEBHOOK_BODY_TEMPLATE))
@@ -79,9 +81,7 @@ class TestSQSRequeue(MockSQSTestCase):
             event={
                 "Records": [
                     {
-                        "messageAttributes": {
-                            "X-GitHub-Event": {"stringValue": None}
-                        },
+                        "messageAttributes": {"X-GitHub-Event": {"stringValue": None}},
                         "body": json.dumps(WEBHOOK_BODY_TEMPLATE),
                     }
                 ]
@@ -90,9 +90,10 @@ class TestSQSRequeue(MockSQSTestCase):
         )
         self.assertEqual(response["statusCode"], "400")
 
-        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get("Messages")
+        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get(
+            "Messages"
+        )
         self.assertIsNone(messages)
-
 
 
 if __name__ == "__main__":

--- a/test/test_handler.py
+++ b/test/test_handler.py
@@ -1,8 +1,9 @@
 import json
+import hmac
 from python_dynamodb_lock.python_dynamodb_lock import DynamoDBLockError  # type: ignore
 from unittest.mock import patch
 
-from src.handler import handle_github_webhook
+import src.handler as handler
 from test.impl.base_test_case_class import BaseClass
 from test.impl.mock_sqs_test_case import MockSQSTestCase
 
@@ -16,28 +17,24 @@ WEBHOOK_BODY_TEMPLATE = {
 
 class TestHandleGithubWebhook(BaseClass):
     def test_validate_headers(self):
-        response = handle_github_webhook(None, None, None)
+        response = handler.handle_github_webhook(None, None)
         self.assertEqual(response["statusCode"], "400")
 
     @patch("src.aws.lock.dynamodb_lock_client.acquire_lock")
     def test_swallows_dynamodb_lock_error(self, _mock_lock):
         _mock_lock.side_effect = DynamoDBLockError("error")
-        response = handle_github_webhook(
+        response = handler.handle_github_webhook(
             event_type="pull_request",
-            delivery_id="123",
             webhook_body=json.dumps(WEBHOOK_BODY_TEMPLATE),
-            should_retry=False,
         )
 
         self.assertEqual(response["statusCode"], "500")
         self.assertEqual(response["body"], "DynamoDBLockError: error - Unknown error")
 
     def test_throws_all_other_errors(self):
-        response = handle_github_webhook(
+        response = handler.handle_github_webhook(
             event_type="not_found",
-            delivery_id="123",
             webhook_body=json.dumps(WEBHOOK_BODY_TEMPLATE),
-            should_retry=False,
         )
 
         self.assertEqual(response["statusCode"], "501")
@@ -45,11 +42,9 @@ class TestHandleGithubWebhook(BaseClass):
 
         with patch("src.github.webhook.handle_github_webhook") as mock:
             mock.side_effect = Exception("error")
-            response = handle_github_webhook(
+            response = handler.handle_github_webhook(
                 event_type="pull_request",
-                delivery_id="123",
                 webhook_body=json.dumps(WEBHOOK_BODY_TEMPLATE),
-                should_retry=False,
             )
 
         self.assertEqual(response["statusCode"], "500")
@@ -57,23 +52,47 @@ class TestHandleGithubWebhook(BaseClass):
 
 
 class TestSQSRequeue(MockSQSTestCase):
+    @patch.object(hmac, "compare_digest", return_value=True)
     @patch("src.aws.lock.dynamodb_lock_client.acquire_lock")
-    def test_requeue_on_error(self, _mock_lock):
+    def test_requeue_on_error(self, _mock_lock, _mock_compare_digest):
         _mock_lock.side_effect = DynamoDBLockError("error")
         with patch("src.aws.sqs_client.SQS_URL", self.test_queue_url):
-            response = handle_github_webhook(
-                event_type="pull_request",
-                delivery_id="123",
-                webhook_body=json.dumps(WEBHOOK_BODY_TEMPLATE),
-                should_retry=True,
+            response = handler.handler(
+                event={
+                    "headers": {
+                        "X-GitHub-Event": "pull_request",
+                        "X-Hub-Signature": "sha1=1234",
+                    },
+                    "body": json.dumps(WEBHOOK_BODY_TEMPLATE),
+                },
+                context={}
             )
-
         self.assertEqual(response["statusCode"], "500")
 
-        messages = self.client.receive_message(QueueUrl=self.test_queue_url)["Messages"]
+        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get("Messages", [])
 
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0]["Body"], json.dumps(WEBHOOK_BODY_TEMPLATE))
+
+    def test_no_requeue_for_sqs_event(self):
+        response = handler.handler(
+            event={
+                "Records": [
+                    {
+                        "messageAttributes": {
+                            "X-GitHub-Event": {"stringValue": None}
+                        },
+                        "body": json.dumps(WEBHOOK_BODY_TEMPLATE),
+                    }
+                ]
+            },
+            context={},
+        )
+        self.assertEqual(response["statusCode"], "400")
+
+        messages = self.client.receive_message(QueueUrl=self.test_queue_url).get("Messages")
+        self.assertIsNone(messages)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

- shifted retrying up so we don't need to pass delivery_id or `should_retry` through
- also added queue events or when task_ids are not found to do a full sync
- also added the PR queue event when `LGTM` or some variety is commented
- did _not_ add a retry to the `upsert_pull_request` handler because there's a chance we infinite loop

Asana tasks:
https://app.asana.com/0/1200740774079340/1207463488975792/f


Relevant deployment: 

CC: @vn6 @prebeta @suzyng83209 @michael-huang87

### Test Plan

- [x] tests pass on this pr
- [x] staging works where commenting LGTM post merge closes the task https://github.com/Asana/testing-sgtm/pull/3

### Risks

Asana tasks: https://app.asana.com/0/1200740774079340/1207463488975792/f

Primary reviewer: vn6

Other reviewers: 

cc: prebeta,suzyng83209,vn6,michael-huang87

Relevant Deployment:

Pull Request: https://github.com/Asana/SGTM/pull/189



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207489920817270)