### PR TITLE
[Merge Queues] Add merge queue status

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -85,6 +85,8 @@ def default_due_date_str(reference_datetime: Optional[datetime] = None) -> str:
 def _task_status_from_pull_request(pull_request: PullRequest) -> str:
     if pull_request.closed():
         return "Merged" if pull_request.merged() else "Closed"
+    elif pull_request.is_in_merge_queue():
+        return "Queued"
     else:
         return "Draft" if pull_request.is_draft() else "Open"
 
@@ -122,7 +124,7 @@ _custom_fields_to_extract_map = {
 def _custom_fields_from_pull_request(pull_request: PullRequest) -> Dict:
     """
     We currently expect the project to have three custom fields with its corresponding enum options:
-        • PR Status: "Open", "Draft", "Closed", "Merged"
+        • PR Status: "Open", "Draft", "Closed", "Queued", "Merged"
         • Build: "Success", "Failure"
         • Review Status: "Needs Review", "Changes Requested", "Approved", "Not Ready"
     """

--- a/src/github/graphql/fragments/FullPullRequest.py
+++ b/src/github/graphql/fragments/FullPullRequest.py
@@ -15,6 +15,7 @@ fragment FullPullRequest on PullRequest {
   closed
   merged
   isDraft
+  isInMergeQueue
   mergedAt
   mergeable
   url

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -244,8 +244,8 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
 # returns True if the pull request was automerged, False if not
 def maybe_automerge_pull_request(pull_request: PullRequest) -> bool:
     is_pull_request_ready_for_automerge = False
-    if not SGTM_FEATURE__AUTOMERGE_ENABLED or not _pull_request_is_open(pull_request):
-        logger.info(f"Skipping automerge for {pull_request.id()} because it is closed")
+    if not SGTM_FEATURE__AUTOMERGE_ENABLED or not _pull_request_is_open(pull_request) or pull_request.is_in_merge_queue():
+        logger.info(f"Skipping automerge for {pull_request.id()} because it is closed or in merge queue")
         is_pull_request_ready_for_automerge = False
 
     # if there are multiple labels, we use the most permissive to define automerge behavior

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -244,8 +244,14 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
 # returns True if the pull request was automerged, False if not
 def maybe_automerge_pull_request(pull_request: PullRequest) -> bool:
     is_pull_request_ready_for_automerge = False
-    if not SGTM_FEATURE__AUTOMERGE_ENABLED or not _pull_request_is_open(pull_request) or pull_request.is_in_merge_queue():
-        logger.info(f"Skipping automerge for {pull_request.id()} because it is closed or in merge queue")
+    if (
+        not SGTM_FEATURE__AUTOMERGE_ENABLED
+        or not _pull_request_is_open(pull_request)
+        or pull_request.is_in_merge_queue()
+    ):
+        logger.info(
+            f"Skipping automerge for {pull_request.id()} because it is closed or in merge queue"
+        )
         is_pull_request_ready_for_automerge = False
 
     # if there are multiple labels, we use the most permissive to define automerge behavior

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -190,6 +190,9 @@ class PullRequest(object):
     def is_build_successful(self) -> bool:
         return self.build_status() == Commit.BUILD_SUCCESSFUL
 
+    def is_in_merge_queue(self) -> bool:
+        return self._raw["isInMergeQueue"]
+
     def merged_at(self) -> Optional[datetime]:
         merged_at = self._raw.get("mergedAt", None)
         if merged_at is None:

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -166,7 +166,6 @@ def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")
 
-
 _events_map = {
     "pull_request": _handle_pull_request_webhook,
     "issue_comment": _handle_issue_comment_webhook,

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -166,6 +166,7 @@ def _handle_check_suite_webhook(payload: dict) -> HttpResponse:
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")
 
+
 _events_map = {
     "pull_request": _handle_pull_request_webhook,
     "issue_comment": _handle_issue_comment_webhook,

--- a/test/asana/helpers/test_task_status_from_pull_request.py
+++ b/test/asana/helpers/test_task_status_from_pull_request.py
@@ -27,6 +27,13 @@ class TestTaskStatusFromPullRequest(BaseClass):
         task_status = _task_status_from_pull_request(pull_request)
         self.assertEqual("Draft", task_status)
 
+    def test_queued(self):
+        pull_request = build(
+            builder.pull_request().closed(False).merged(False).isDraft(False).isInMergeQueue(True)
+        )
+        task_status = _task_status_from_pull_request(pull_request)
+        self.assertEqual("Queued", task_status)
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests

--- a/test/asana/helpers/test_task_status_from_pull_request.py
+++ b/test/asana/helpers/test_task_status_from_pull_request.py
@@ -29,7 +29,11 @@ class TestTaskStatusFromPullRequest(BaseClass):
 
     def test_queued(self):
         pull_request = build(
-            builder.pull_request().closed(False).merged(False).isDraft(False).isInMergeQueue(True)
+            builder.pull_request()
+            .closed(False)
+            .merged(False)
+            .isDraft(False)
+            .isInMergeQueue(True)
         )
         task_status = _task_status_from_pull_request(pull_request)
         self.assertEqual("Queued", task_status)

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -455,7 +455,7 @@ class TestMaybeAutomergePullRequest(unittest.TestCase):
                 .state(ReviewState.APPROVED)
             )
             .isInMergeQueue(True)
-            .mergeable(MergeableState.CONFLICTING)
+            .mergeable(MergeableState.MERGEABLE)
             .merged(False)
             .label(builder.label().name(github_logic.AutomergeLabel.AFTER_TESTS.value))
         )

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -442,6 +442,25 @@ class TestMaybeAutomergePullRequest(unittest.TestCase):
         self.assertFalse(github_logic.maybe_automerge_pull_request(pull_request))
         mock_merge_pull_request.assert_not_called()
 
+    @patch("src.github.logic.SGTM_FEATURE__AUTOMERGE_ENABLED", True)
+    def test_is_pull_request_ready_for_automerge_when_in_merge_queue(
+        self, mock_merge_pull_request
+    ):
+        pull_request = build(
+            builder.pull_request()
+            .commit(builder.commit().status(Commit.BUILD_SUCCESSFUL))
+            .review(
+                builder.review()
+                .submitted_at("2020-01-13T14:59:58Z")
+                .state(ReviewState.APPROVED)
+            )
+            .isInMergeQueue(True)
+            .mergeable(MergeableState.CONFLICTING)
+            .merged(False)
+            .label(builder.label().name(github_logic.AutomergeLabel.AFTER_TESTS.value))
+        )
+        self.assertFalse(github_logic.maybe_automerge_pull_request(pull_request))
+        mock_merge_pull_request.assert_not_called()
 
 class TestPullRequestHasLabel(unittest.TestCase):
     def test_pull_request_with_label(self):

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -462,6 +462,7 @@ class TestMaybeAutomergePullRequest(unittest.TestCase):
         self.assertFalse(github_logic.maybe_automerge_pull_request(pull_request))
         mock_merge_pull_request.assert_not_called()
 
+
 class TestPullRequestHasLabel(unittest.TestCase):
     def test_pull_request_with_label(self):
         label_name = "test label"

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -45,6 +45,7 @@ class PullRequestBuilder(BuilderBaseClass):
             "comments": {"nodes": []},
             "reviews": {"nodes": []},
             "reviewRequests": {"nodes": []},
+            "isInMergeQueue": False,
             "closed": False,
             "merged": False,
             "isDraft": False,

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -91,7 +91,7 @@ class PullRequestBuilder(BuilderBaseClass):
         self.raw_pr["body"] = body
         return self
 
-    def is_in_merge_queue(self, is_in_merge_queue: bool):
+    def isInMergeQueue(self, is_in_merge_queue: bool):
         self.raw_pr["isInMergeQueue"] = is_in_merge_queue
         return self
 

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -91,6 +91,10 @@ class PullRequestBuilder(BuilderBaseClass):
         self.raw_pr["body"] = body
         return self
 
+    def is_in_merge_queue(self, is_in_merge_queue: bool):
+        self.raw_pr["isInMergeQueue"] = is_in_merge_queue
+        return self
+
     def merged_at(self, merged_at: Union[str, datetime]):
         self.raw_pr["mergedAt"] = transform_datetime(merged_at)
         return self


### PR DESCRIPTION
### Summary

- add "queued" status to indicate when PR is in merge queue, status will change back to "open" on eviction or "merged" after merge

Asana tasks:
https://app.asana.com/0/1203954674308315/1207270814999856/f


Relevant deployment: 

CC: @prebeta @suzyng83209

### Test Plan

- tested with https://app.asana.com/0/1203954674308315/1207650446738621/f (didn't get a screenshot in time before it changed to merged but it worked)

### Risks



Pull Request: https://github.com/Asana/SGTM/pull/192



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207651182135382)