### PR TITLE
Add branch deletion exceptions

### DIFF
--- a/src/github/graphql/client.py
+++ b/src/github/graphql/client.py
@@ -7,6 +7,7 @@ from .queries import (
     GetPullRequestByRepositoryAndNumber,
     GetPullRequestAndComment,
     GetPullRequestAndReview,
+    GetRepository,
     IteratePullRequestIdsForCommitId,
     IterateReviewsForPullRequestId,
 )
@@ -146,3 +147,8 @@ def get_review_for_database_id(
                 },
             )["node"]["reviews"]["edges"]
     return None
+
+
+def get_repository(repository_id: str):
+    data = _execute_graphql_query(GetRepository, {"repositoryId": repository_id})
+    return data["repository"]

--- a/src/github/graphql/queries/GetRepository.py
+++ b/src/github/graphql/queries/GetRepository.py
@@ -1,0 +1,17 @@
+from typing import FrozenSet
+
+# @GraphqlInPython
+_get_repository = """
+query GetRepository($repositoryId: ID!) {
+  repository: node($repositoryId: ID!) {
+    ... on Repository {
+      deleteBranchOnMerge
+      defaultBranchRef{
+        name
+      }
+    }
+  }
+}
+"""
+
+GetRepository: FrozenSet[str] = frozenset([_get_repository])

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -301,7 +301,8 @@ def maybe_delete_branch_if_merged(pull_request: PullRequest):
         owner = pull_request.repository_owner_handle()
         repo_name = pull_request.repository_name()
         branch_name = pull_request.head_ref_name()
-        github_client.delete_branch_if_exists(owner, repo_name, branch_name)
+        if branch_name not in ["master", "main"]:
+            github_client.delete_branch_if_exists(owner, repo_name, branch_name)
 
 
 # ----------------------------------------------------------------------------------

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -296,12 +296,12 @@ def maybe_automerge_pull_request(pull_request: PullRequest) -> bool:
     return False
 
 
-def maybe_delete_branch_if_merged(pull_request: PullRequest):
+def maybe_delete_branch_if_merged(pull_request: PullRequest, repository):
     if pull_request.merged():
         owner = pull_request.repository_owner_handle()
         repo_name = pull_request.repository_name()
         branch_name = pull_request.head_ref_name()
-        if branch_name not in ["master", "main"]:
+        if branch_name == repository.default_branch and repository.deleteBranchOnMerge:
             github_client.delete_branch_if_exists(owner, repo_name, branch_name)
 
 

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -301,7 +301,7 @@ def maybe_delete_branch_if_merged(pull_request: PullRequest, repository):
         owner = pull_request.repository_owner_handle()
         repo_name = pull_request.repository_name()
         branch_name = pull_request.head_ref_name()
-        if branch_name != repository.default_branch and repository.deleteBranchOnMerge:
+        if branch_name != repository["default_branch"] and repository["deleteBranchOnMerge"]:
             github_client.delete_branch_if_exists(owner, repo_name, branch_name)
 
 

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -301,7 +301,7 @@ def maybe_delete_branch_if_merged(pull_request: PullRequest, repository):
         owner = pull_request.repository_owner_handle()
         repo_name = pull_request.repository_name()
         branch_name = pull_request.head_ref_name()
-        if branch_name == repository.default_branch and repository.deleteBranchOnMerge:
+        if branch_name != repository.default_branch and repository.deleteBranchOnMerge:
             github_client.delete_branch_if_exists(owner, repo_name, branch_name)
 
 

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -19,7 +19,8 @@ def _handle_pull_request_webhook(payload: dict) -> HttpResponse:
         # a label change will trigger this webhook, so it may trigger automerge
         github_logic.maybe_automerge_pull_request(pull_request)
         if payload["action"] == "closed":
-            github_logic.maybe_delete_branch_if_merged(pull_request)
+            repository = graphql_client.get_repository(pull_request.repository_id())
+            github_logic.maybe_delete_branch_if_merged(pull_request, repository)
         github_logic.maybe_add_automerge_warning_comment(pull_request)
         github_controller.upsert_pull_request(pull_request)
         return HttpResponse("200")

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -622,6 +622,13 @@ class TestMaybeDeleteBranchIfMerged(unittest.TestCase):
         github_logic.maybe_delete_branch_if_merged(pull_request)
         mock_delete_branch.assert_not_called()
 
+    def test_do_not_delete_main_branch(self, mock_delete_branch):
+        pull_request = build(
+            builder.pull_request().merged(True).head_ref_name("main")
+        )
+        github_logic.maybe_delete_branch_if_merged(pull_request)
+        mock_delete_branch.assert_not_called()
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -628,7 +628,7 @@ class TestMaybeDeleteBranchIfMerged(unittest.TestCase):
         github_logic.maybe_delete_branch_if_merged(pull_request, repository)
         mock_delete_branch.assert_not_called()
 
-    def test_do_not_delete_default_branch(self, mock_delete_branch):
+    def test_do_not_delete_if_repo_setting(self, mock_delete_branch):
         pull_request = build(
             builder.pull_request().merged(True).head_ref_name("feature-branch")
         )

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -623,9 +623,7 @@ class TestMaybeDeleteBranchIfMerged(unittest.TestCase):
         mock_delete_branch.assert_not_called()
 
     def test_do_not_delete_main_branch(self, mock_delete_branch):
-        pull_request = build(
-            builder.pull_request().merged(True).head_ref_name("main")
-        )
+        pull_request = build(builder.pull_request().merged(True).head_ref_name("main"))
         github_logic.maybe_delete_branch_if_merged(pull_request)
         mock_delete_branch.assert_not_called()
 

--- a/test/github/test_logic.py
+++ b/test/github/test_logic.py
@@ -622,9 +622,21 @@ class TestMaybeDeleteBranchIfMerged(unittest.TestCase):
         github_logic.maybe_delete_branch_if_merged(pull_request)
         mock_delete_branch.assert_not_called()
 
-    def test_do_not_delete_main_branch(self, mock_delete_branch):
+    def test_do_not_delete_default_branch(self, mock_delete_branch):
         pull_request = build(builder.pull_request().merged(True).head_ref_name("main"))
-        github_logic.maybe_delete_branch_if_merged(pull_request)
+        repository = {"deleteBranchOnMerge": True, "defaultBranchRef": {"name": "main"}}
+        github_logic.maybe_delete_branch_if_merged(pull_request, repository)
+        mock_delete_branch.assert_not_called()
+
+    def test_do_not_delete_default_branch(self, mock_delete_branch):
+        pull_request = build(
+            builder.pull_request().merged(True).head_ref_name("feature-branch")
+        )
+        repository = {
+            "deleteBranchOnMerge": False,
+            "defaultBranchRef": {"name": "main"},
+        }
+        github_logic.maybe_delete_branch_if_merged(pull_request, repository)
         mock_delete_branch.assert_not_called()
 
 


### PR DESCRIPTION
### Summary

https://github.com/Asana/SGTM/pull/193 started deleting "main" branches when PRs were being made from that branch. Add some logic to ignore deletion logic for certain branches. We could maybe make this configurable through an env variable but not sure how useful that would be

Asana tasks:
https://app.asana.com/0/1202309366996843/1207707608547616/f

### Test Plan


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207708659445679)