### PR TITLE
[SGTM functionality] don't automerge if the baseref has at least 1 open PR

### DIFF
--- a/src/github/graphql/fragments/FullPullRequest.py
+++ b/src/github/graphql/fragments/FullPullRequest.py
@@ -5,7 +5,11 @@ from typing import FrozenSet
 _full_pull_request = """
 fragment FullPullRequest on PullRequest {
   id
-  baseRefName
+  baseRef {
+    associatedPullRequests(states: OPEN, first: 1) {
+      totalCount
+    }
+  }
   body
   bodyHTML
   title

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -235,8 +235,8 @@ def maybe_add_automerge_warning_comment(pull_request: PullRequest):
     # if a PR has an automerge label and doesn't contain a comment warning, we want to maybe add a warning comment
     # only add warning comment if it's set to auto-merge after approval and hasn't yet been approved to limit noise
 
-    if automerge_comment and not _pull_request_has_automerge_comment(
-        pull_request, automerge_comment
+    if automerge_comment and not any(
+        comment.body() == automerge_comment for comment in pull_request.comments()
     ):
         github_client.add_pr_comment(
             owner=pull_request.repository_owner_handle(),
@@ -256,7 +256,7 @@ def maybe_automerge_pull_request(pull_request: PullRequest) -> bool:
         or pull_request.base_ref_associated_pull_requests() > 0
     ):
         logger.info(
-            f"Skipping automerge for {pull_request.id()} because it is closed or in merge queue"
+            f"Skipping automerge for {pull_request.id()} because it is closed, in merge queue, or the base branch has open PRs associated with it."
         )
         is_pull_request_ready_for_automerge = False
 
@@ -309,11 +309,3 @@ def maybe_automerge_pull_request(pull_request: PullRequest) -> bool:
 
 def _pull_request_is_open(pull_request: PullRequest) -> bool:
     return not pull_request.closed() and not pull_request.merged()
-
-
-def _pull_request_has_automerge_comment(
-    pull_request: PullRequest, automerge_comment: str
-) -> bool:
-    return any(
-        comment.body() == automerge_comment for comment in pull_request.comments()
-    )

--- a/src/github/models/pull_request.py
+++ b/src/github/models/pull_request.py
@@ -217,5 +217,5 @@ class PullRequest(object):
     def labels(self) -> List[Label]:
         return [Label(label) for label in self._raw["labels"]["nodes"]]
 
-    def base_ref_name(self) -> str:
-        return self._raw["baseRefName"]
+    def base_ref_associated_pull_requests(self) -> int:
+        return self._raw["baseRef"]["associatedPullRequests"]["totalCount"]

--- a/test/impl/builders/pull_request_builder.py
+++ b/test/impl/builders/pull_request_builder.py
@@ -26,7 +26,10 @@ class PullRequestBuilder(BuilderBaseClass):
             "id": create_uuid(),
             "number": pr_number,
             "body": body,
-            "baseRefName": create_uuid(),
+            "baseRef": {
+                "name": create_uuid(),
+                "associatedPullRequests": {"totalCount": 0},
+            },
             "title": create_uuid(),
             "url": "https://www.github.com/foo/pulls/" + str(pr_number),
             "assignees": {"nodes": []},
@@ -164,8 +167,10 @@ class PullRequestBuilder(BuilderBaseClass):
         )
         return self
 
-    def base_ref_name(self, base_ref_name: str):
-        self.raw_pr["baseRefName"] = base_ref_name
+    def base_ref_associated_pull_requests(self, associated_pull_requests: int):
+        self.raw_pr["baseRef"]["associatedPullRequests"][
+            "totalCount"
+        ] = associated_pull_requests
         return self
 
     def build(self) -> PullRequest:


### PR DESCRIPTION
### Summary

- sometimes people attach automerge to upstream PRs in a stack and get surprised when it gets merged into their downstream PR
- This prevents that issue from happening by querying for the number of open PRs associated with the base ref of the PR with the label and adds a warning to indicate that the automerge will not work until the downstream PR is closed/merged/etc.
- This is how graphite does things

Asana tasks:
https://app.asana.com/0/1207092173713920/1207857085291812/f


Relevant deployment: 

CC: @vn6 @prebeta @suzyng83209 @michael-huang87

### Test Plan
- [x] SGTM comments on PR with open base PR: https://github.com/Asana/testing-sgtm/pull/13
- [x] SGTM does not comment if there is no open PR and uses the regular one: https://github.com/Asana/testing-sgtm/pull/12
- [x] SGTM does not merge a PR into a branch with an open PR: https://github.com/Asana/testing-sgtm/pull/13
- [x] SGTM still merges properly to base branch with no open PR: https://github.com/Asana/testing-sgtm/pull/13
- [x] SGTM merges an upstream PR as soon as its downstream PR is merged: https://github.com/Asana/testing-sgtm/pull/14


### Risks



Pull Request: https://github.com/Asana/SGTM/pull/197



Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1207928499342923)