### PR TITLE
[SGTM Post-merge reviews] Accept post-merge reviews with state=APPROVED

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,20 +199,22 @@ You can also choose to test your changes locally. Here are step-by-step instruct
 You may then run all tests via the command line:
 
 ```bash
-ENV=test python3 -m unittest discover
+pipenv install --dev
+ENV=test pipenv run python3 -m unittest
 ```
 
 Alternatively, you may run specific tests e.g. via:
 
 ```bash
-ENV=test python3 -m unittest test/<python-test-file-name>.py
-ENV=test python3 -m unittest test.<python-test-module-name>.<TestClassName>
-ENV=test python3 -m unittest test.<python-test-module-name>.<TestClassName>.<test_function_name>
+pipenv install --dev
+ENV=test pipenv run python3 -m unittest test/<python-test-file-name>.py
+ENV=test pipenv run python3 -m unittest test.<python-test-module-name>.<TestClassName>
+ENV=test pipenv run python3 -m unittest test.<python-test-module-name>.<TestClassName>.<test_function_name>
 ```
 
 ## "Building"
 Please perform the following checks prior to pushing code
 
-* run `black .` to autoformat your code
+* run `pipenv run black .` to autoformat your code
 * run `mypy` on each file that you have changed
 * run tests, as described in the [previous section](#running-tests)

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -198,16 +198,14 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
             and review.author().login()
             not in SGTM_FEATURE__FOLLOWUP_REVIEW_GITHUB_USERS
         ]
+
+        if any(review.is_approval() for review in postmerge_reviews):
+            return True
+
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews
         ]
-        return bool(
-            [
-                body_text
-                for body_text in body_texts
-                if _is_approval_comment_body(body_text)
-            ]
-        )
+        return any(_is_approval_comment_body(body_text) for body_text in body_texts)
     return False
 
 

--- a/test/github/test_is_pull_request_ready_for_automerge.py
+++ b/test/github/test_is_pull_request_ready_for_automerge.py
@@ -163,7 +163,7 @@ class GithubLogicTest(unittest.TestCase):
         commented_at = merged_at + timedelta(days=2)
         pull_request = build(
             builder.pull_request()
-            .merged_at(datetime.now())
+            .merged_at(merged_at)
             .merged(True)
             .reviews(
                 [
@@ -188,7 +188,7 @@ class GithubLogicTest(unittest.TestCase):
         commented_at = merged_at + timedelta(days=2)
         pull_request = build(
             builder.pull_request()
-            .merged_at(datetime.now())
+            .merged_at(merged_at)
             .merged(True)
             .reviews(
                 [
@@ -213,7 +213,7 @@ class GithubLogicTest(unittest.TestCase):
         commented_at = merged_at + timedelta(days=2)
         pull_request = build(
             builder.pull_request()
-            .merged_at(datetime.now())
+            .merged_at(merged_at)
             .merged(True)
             .reviews(
                 [
@@ -227,6 +227,23 @@ class GithubLogicTest(unittest.TestCase):
                     builder.comment("v cool use of emojis")
                     .published_at(commented_at)
                     .author(builder.user("human"))
+                ]
+            )
+        )
+        self.assertTrue(github_logic.pull_request_approved_after_merging(pull_request))
+
+    def test_pull_request_approved_by_review_after_merging(self):
+        merged_at = datetime.now()
+        reviewed_at = merged_at + timedelta(days=1)
+        pull_request = build(
+            builder.pull_request()
+            .merged_at(merged_at)
+            .merged(True)
+            .reviews(
+                [
+                    builder.review()
+                    .submitted_at(reviewed_at)
+                    .state(ReviewState.APPROVED)
                 ]
             )
         )

--- a/test/impl/builders/review_builder.py
+++ b/test/impl/builders/review_builder.py
@@ -14,6 +14,7 @@ class ReviewBuilder(BuilderBaseClass):
             "body": body,
             "author": {"login": "somebody", "name": ""},
             "comments": {"nodes": []},
+            "state": "DEFAULT",
             "url": "",
         }
 


### PR DESCRIPTION
Currently, SGTM ignores reviews' "state" field if they occur after merge.  This didn't impact us before because the GitHub Review UI only allows "comment" reviews after merge.

Other GitHub Review front-ends such as Graphite are not as strict and allow creating an "approved" review after merge.  This patch changes SGTM to read this field on post-merge reviews.

https://app.asana.com/0/1149418478823393/1208471413831246

Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1209470041710099)
Pull Request: https://github.com/Asana/SGTM/pull/204