### PR TITLE
handle cases where http_response is None in error handling

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -30,6 +30,8 @@ def handle_github_webhook(event_type: str, webhook_body: str) -> HttpResponseDic
         logger.error(traceback.format_exc())
         http_response = HttpResponse("500", str(error))
     finally:
+        if http_response is None: # handle_github_webhook can occasionally return None
+            http_response = HttpResponse("500", "Unknown error")
         return http_response.to_dict()
 
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -30,7 +30,7 @@ def handle_github_webhook(event_type: str, webhook_body: str) -> HttpResponseDic
         logger.error(traceback.format_exc())
         http_response = HttpResponse("500", str(error))
     finally:
-        if http_response is None: # handle_github_webhook can occasionally return None
+        if http_response is None:  # handle_github_webhook can occasionally return None
             http_response = HttpResponse("500", "Unknown error")
         return http_response.to_dict()
 

--- a/test/github/test_is_pull_request_ready_for_automerge.py
+++ b/test/github/test_is_pull_request_ready_for_automerge.py
@@ -240,11 +240,7 @@ class GithubLogicTest(unittest.TestCase):
             .merged_at(merged_at)
             .merged(True)
             .reviews(
-                [
-                    builder.review()
-                    .submitted_at(reviewed_at)
-                    .state(ReviewState.APPROVED)
-                ]
+                [builder.review().submitted_at(reviewed_at).state(ReviewState.APPROVED)]
             )
         )
         self.assertTrue(github_logic.pull_request_approved_after_merging(pull_request))


### PR DESCRIPTION
Somehow, `github_webhook.handle_github_webhook` can return None, making the lambda crash without any way to retry. Here we fix.

NB: Currently testing on staging but figure there's no drawback to putting this up now.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1209793023817026)
Pull Request: https://github.com/Asana/SGTM/pull/205