### PR TITLE
pass in organization field to prevent crashes on requeue'd approval comments

### DIFF
--- a/src/aws/sqs_client.py
+++ b/src/aws/sqs_client.py
@@ -95,6 +95,6 @@ def queue_new_event(event_type: str, body: str):
     )
 
 
-def queue_full_sync(pull_request_id: str):
-    body = {"pull_request": {"node_id": pull_request_id}}
+def queue_full_sync(pull_request_id: str, organization: str):
+    body = {"pull_request": {"node_id": pull_request_id}, "organization": {"login": organization}}
     queue_new_event("pull_request", json.dumps(body))

--- a/src/aws/sqs_client.py
+++ b/src/aws/sqs_client.py
@@ -95,9 +95,9 @@ def queue_new_event(event_type: str, body: str):
     )
 
 
-def queue_full_sync(pull_request_id: str, organization: str):
+def queue_full_sync(pull_request_id: str, org_name: str):
     body = {
         "pull_request": {"node_id": pull_request_id},
-        "organization": {"login": organization},
+        "organization": {"login": org_name},
     }
     queue_new_event("pull_request", json.dumps(body))

--- a/src/aws/sqs_client.py
+++ b/src/aws/sqs_client.py
@@ -96,5 +96,8 @@ def queue_new_event(event_type: str, body: str):
 
 
 def queue_full_sync(pull_request_id: str, organization: str):
-    body = {"pull_request": {"node_id": pull_request_id}, "organization": {"login": organization}}
+    body = {
+        "pull_request": {"node_id": pull_request_id},
+        "organization": {"login": organization},
+    }
     queue_new_event("pull_request", json.dumps(body))

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -50,23 +50,23 @@ def _add_asana_task_to_pull_request(pull_request: PullRequest, task_id: str):
     pull_request.set_body(new_body)
 
 
-def upsert_comment(pull_request: PullRequest, comment: Comment):
+def upsert_comment(pull_request: PullRequest, comment: Comment, organization: str):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id:
         if not comment.author().is_bot():
             asana_controller.upsert_github_comment_to_task(comment, task_id)
         # Comments can sometimes post-merge approve a PR, so we requeue a full sync via the "pull_request" event
-        if github_logic._is_approval_comment_body(comment.body()):
-            sqs_client.queue_full_sync(pull_request_id)
+        if github_logic.is_approval_comment_body(comment.body()):
+            sqs_client.queue_full_sync(pull_request_id, organization)
     else:
         logger.warning(
             f"Task not found for pull request {pull_request_id}. Queueing a new event..."
         )
-        sqs_client.queue_full_sync(pull_request_id)
+        sqs_client.queue_full_sync(pull_request_id, organization)
 
 
-def upsert_review(pull_request: PullRequest, review: Review):
+def upsert_review(pull_request: PullRequest, review: Review, organization: str):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id:
@@ -98,7 +98,7 @@ def upsert_review(pull_request: PullRequest, review: Review):
         logger.warning(
             f"Task not found for pull request {pull_request_id}. Queueing a new event..."
         )
-        sqs_client.queue_full_sync(pull_request_id)
+        sqs_client.queue_full_sync(pull_request_id, organization)
 
 
 def assign_pull_request_to_author(pull_request: PullRequest):

--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -50,7 +50,7 @@ def _add_asana_task_to_pull_request(pull_request: PullRequest, task_id: str):
     pull_request.set_body(new_body)
 
 
-def upsert_comment(pull_request: PullRequest, comment: Comment, organization: str):
+def upsert_comment(pull_request: PullRequest, comment: Comment, org_name: str):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id:
@@ -58,15 +58,15 @@ def upsert_comment(pull_request: PullRequest, comment: Comment, organization: st
             asana_controller.upsert_github_comment_to_task(comment, task_id)
         # Comments can sometimes post-merge approve a PR, so we requeue a full sync via the "pull_request" event
         if github_logic.is_approval_comment_body(comment.body()):
-            sqs_client.queue_full_sync(pull_request_id, organization)
+            sqs_client.queue_full_sync(pull_request_id, org_name)
     else:
         logger.warning(
             f"Task not found for pull request {pull_request_id}. Queueing a new event..."
         )
-        sqs_client.queue_full_sync(pull_request_id, organization)
+        sqs_client.queue_full_sync(pull_request_id, org_name)
 
 
-def upsert_review(pull_request: PullRequest, review: Review, organization: str):
+def upsert_review(pull_request: PullRequest, review: Review, org_name: str):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id:
@@ -98,7 +98,7 @@ def upsert_review(pull_request: PullRequest, review: Review, organization: str):
         logger.warning(
             f"Task not found for pull request {pull_request_id}. Queueing a new event..."
         )
-        sqs_client.queue_full_sync(pull_request_id, organization)
+        sqs_client.queue_full_sync(pull_request_id, org_name)
 
 
 def assign_pull_request_to_author(pull_request: PullRequest):

--- a/src/github/logic.py
+++ b/src/github/logic.py
@@ -147,7 +147,7 @@ def pull_request_approved_before_merging(
     return ApprovedBeforeMergeStatus.APPROVED
 
 
-def _is_approval_comment_body(body: str) -> bool:
+def is_approval_comment_body(body: str) -> bool:
     return (
         re.search(
             "sgtm|lgtm|sounds good|sound good|looks good|look good|looks great|look"
@@ -205,7 +205,7 @@ def pull_request_approved_after_merging(pull_request: PullRequest) -> bool:
         body_texts = [c.body() for c in postmerge_comments] + [
             r.body() for r in postmerge_reviews
         ]
-        return any(_is_approval_comment_body(body_text) for body_text in body_texts)
+        return any(is_approval_comment_body(body_text) for body_text in body_texts)
     return False
 
 

--- a/src/github/webhook.py
+++ b/src/github/webhook.py
@@ -38,7 +38,7 @@ def _handle_issue_comment_webhook(payload: dict) -> HttpResponse:
             pull_request, comment = graphql_client.get_pull_request_and_comment(
                 org_name, issue_id, comment_id
             )
-            github_controller.upsert_comment(pull_request, comment)
+            github_controller.upsert_comment(pull_request, comment, org_name)
         return HttpResponse("200")
 
     if action == "deleted":
@@ -62,7 +62,7 @@ def _handle_pull_request_review_webhook(payload: dict) -> HttpResponse:
             org_name, pull_request_id, review_id
         )
         github_logic.maybe_automerge_pull_request(pull_request)
-        github_controller.upsert_review(pull_request, review)
+        github_controller.upsert_review(pull_request, review, org_name)
     return HttpResponse("200")
 
 
@@ -106,7 +106,7 @@ def _handle_pull_request_review_comment(payload: dict):
                     " request review"
                 )
             review = Review.from_comment(comment)
-            github_controller.upsert_review(pull_request, review)
+            github_controller.upsert_review(pull_request, review, org_name)
         return HttpResponse("200")
 
     if action == "deleted":
@@ -125,7 +125,7 @@ def _handle_pull_request_review_comment(payload: dict):
                 pull_request = graphql_client.get_pull_request(
                     org_name, pull_request_id
                 )
-                github_controller.upsert_review(pull_request, maybe_review)
+                github_controller.upsert_review(pull_request, maybe_review, org_name)
         return HttpResponse("200")
 
     error_text = f"Unknown action for review_comment: {action}"

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -92,7 +92,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
-        organization="the-org"
+        organization = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -139,7 +139,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
-        organization="the-org"
+        organization = "the-org"
 
         github_controller.upsert_comment(pull_request, comment, organization)
         add_comment_mock.assert_not_called()
@@ -161,7 +161,9 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment, organization="organization")
+        github_controller.upsert_comment(
+            pull_request, comment, organization="organization"
+        )
         add_comment_mock.assert_not_called()
 
     @patch.object(asana_controller, "update_task")
@@ -178,7 +180,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().author(author).build()
         bot = builder.user().login("the_bot")
         review = builder.review("LGTM").author(bot).state(ReviewState.APPROVED).build()
-        organization="the-org"
+        organization = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -92,6 +92,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
+        organization="the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -99,8 +100,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment)
-
+        github_controller.upsert_comment(pull_request, comment, organization)
         add_comment_mock.assert_called_with(comment, existing_task_id)
 
     @patch.object(sqs_client, "queue_full_sync")
@@ -116,6 +116,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment("LGTM").author(user).build()
+        organization = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -123,9 +124,9 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment)
+        github_controller.upsert_comment(pull_request, comment, organization)
         add_comment_mock.assert_called_with(comment, existing_task_id)
-        queue_mock.assert_called_with(pull_request.id())
+        queue_mock.assert_called_with(pull_request.id(), organization)
 
     @patch.object(sqs_client, "queue_full_sync")
     @patch.object(asana_controller, "upsert_github_comment_to_task")
@@ -138,10 +139,11 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
+        organization="the-org"
 
-        github_controller.upsert_comment(pull_request, comment)
+        github_controller.upsert_comment(pull_request, comment, organization)
         add_comment_mock.assert_not_called()
-        queue_mock.assert_called_with(pull_request.id())
+        queue_mock.assert_called_with(pull_request.id(), organization)
 
     @patch.object(asana_controller, "upsert_github_comment_to_task")
     def test_no_comment_when_made_by_bot(
@@ -159,7 +161,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment)
+        github_controller.upsert_comment(pull_request, comment, organization="organization")
         add_comment_mock.assert_not_called()
 
     @patch.object(asana_controller, "update_task")
@@ -176,6 +178,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().author(author).build()
         bot = builder.user().login("the_bot")
         review = builder.review("LGTM").author(bot).state(ReviewState.APPROVED).build()
+        organization="the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -183,7 +186,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_review(pull_request, review)
+        github_controller.upsert_review(pull_request, review, organization)
         add_review_mock.assert_not_called()
         set_assignee_mock.assert_called_with(
             pull_request.repository_owner_handle(),

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -92,7 +92,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
-        organization = "the-org"
+        org_name = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -100,7 +100,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment, organization)
+        github_controller.upsert_comment(pull_request, comment, org_name)
         add_comment_mock.assert_called_with(comment, existing_task_id)
 
     @patch.object(sqs_client, "queue_full_sync")
@@ -116,7 +116,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment("LGTM").author(user).build()
-        organization = "the-org"
+        org_name = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -124,9 +124,9 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(pull_request, comment, organization)
+        github_controller.upsert_comment(pull_request, comment, org_name)
         add_comment_mock.assert_called_with(comment, existing_task_id)
-        queue_mock.assert_called_with(pull_request.id(), organization)
+        queue_mock.assert_called_with(pull_request.id(), org_name)
 
     @patch.object(sqs_client, "queue_full_sync")
     @patch.object(asana_controller, "upsert_github_comment_to_task")
@@ -139,11 +139,11 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().build()
         user = builder.user().login("the_author").name("dont-care")
         comment = builder.comment().author(user).build()
-        organization = "the-org"
+        org_name = "the-org"
 
-        github_controller.upsert_comment(pull_request, comment, organization)
+        github_controller.upsert_comment(pull_request, comment, org_name)
         add_comment_mock.assert_not_called()
-        queue_mock.assert_called_with(pull_request.id(), organization)
+        queue_mock.assert_called_with(pull_request.id(), org_name)
 
     @patch.object(asana_controller, "upsert_github_comment_to_task")
     def test_no_comment_when_made_by_bot(
@@ -161,9 +161,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_comment(
-            pull_request, comment, organization="organization"
-        )
+        github_controller.upsert_comment(pull_request, comment, org_name="organization")
         add_comment_mock.assert_not_called()
 
     @patch.object(asana_controller, "update_task")
@@ -180,7 +178,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         pull_request = builder.pull_request().author(author).build()
         bot = builder.user().login("the_bot")
         review = builder.review("LGTM").author(bot).state(ReviewState.APPROVED).build()
-        organization = "the-org"
+        org_name = "the-org"
 
         # Insert the mapping first
         existing_task_id = uuid4().hex
@@ -188,7 +186,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
             pull_request.id(), existing_task_id
         )
 
-        github_controller.upsert_review(pull_request, review, organization)
+        github_controller.upsert_review(pull_request, review, org_name)
         add_review_mock.assert_not_called()
         set_assignee_mock.assert_called_with(
             pull_request.repository_owner_handle(),

--- a/test/github/test_webhook.py
+++ b/test/github/test_webhook.py
@@ -80,7 +80,7 @@ class TestHandlePullRequestReviewComment(MockDynamoDbTestCase):
         get_pull_request_and_comment.assert_called_once_with(
             self.ORG_NAME, self.PULL_REQUEST_NODE_ID, self.COMMENT_NODE_ID
         )
-        upsert_review.assert_called_once_with(pull_request, review)
+        upsert_review.assert_called_once_with(pull_request, review, self.ORG_NAME)
         review_from_comment.assert_called_once_with(comment)
         delete_comment.assert_not_called()
 
@@ -105,7 +105,7 @@ class TestHandlePullRequestReviewComment(MockDynamoDbTestCase):
         get_pull_request.assert_called_once_with(
             self.ORG_NAME, self.PULL_REQUEST_NODE_ID
         )
-        upsert_review.assert_called_once_with(pull_request, review)
+        upsert_review.assert_called_once_with(pull_request, review, self.ORG_NAME)
         get_review_for_database_id.assert_called_once_with(
             self.ORG_NAME, self.PULL_REQUEST_NODE_ID, self.PULL_REQUEST_REVIEW_ID
         )


### PR DESCRIPTION
* This is mostly just minor parameter passing and updating unit tests
* Also tested successfully on staging


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1209885886137189)
Pull Request: https://github.com/Asana/SGTM/pull/206