### PR TITLE
adding more options for s3 terraform backend

### DIFF
--- a/terraform/terragrunt.hcl
+++ b/terraform/terragrunt.hcl
@@ -16,10 +16,15 @@ terraform {
 %{ else }
   backend "s3" {
     bucket = "${get_env("TF_VAR_terraform_backend_s3_bucket_name")}"
+    %{ if get_env("TF_VAR_terraform_backend_s3_use_dynamodb_for_locks", true) }
     dynamodb_table = "sgtm_terraform_state_lock"
+    %{ endif }
+    %{ if get_env("TF_VAR_terraform_backend_s3_use_s3_for_locks", false) }
+    use_lockfile = true
+    %{ endif }
     region = "us-east-1"
 
-    key = "${path_relative_to_include()}/terraform.tfstate"
+    key = "${get_env("TF_VAR_terraform_backend_s3_key_prefix", path_relative_to_include())}/terraform.tfstate"
   }
 %{ endif }
 }


### PR DESCRIPTION
The [Terraform S3 backend ](https://developer.hashicorp.com/terraform/language/backend/s3) supports state locking by default without using DynamoDB for locks. In fact, [that option is deprecated and will be removed in a future version](https://developer.hashicorp.com/terraform/language/backend/s3#state-locking). However, I did not want to change the default behaviour of the state backend so it is still the preferred option.

Also added the option of managing the key prefix from an environment variable.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1210697536520263)
Pull Request: https://github.com/Asana/SGTM/pull/213