### PR TITLE
[Terraform] updates the aws provider to >= 6.0 and make the necessary code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You'll need to have a Terraform Cloud account have the workspace you want to dep
 > terragrunt init
 > terragrunt apply
 ```
-3. Save the output of `terragrunt apply`, which should print out a `api_gateway_deployment_invoke_url`. You'll need this in the next step.
+3. Save the output of `terragrunt apply`, which should print out a `api_gateway_stage_invoke_url`. You'll need this in the next step.
 4. Push your secrets to the ecrypted S3 bucket that Terraform just created. `cd` back to the root of your repository and run: `python3 ./scripts/setup.py secrets` and follow the prompts.
 
 ### Add Mapping of Github Repository -> Asana Project
@@ -106,7 +106,7 @@ For each repository that you are going to sync:
 For each repository that you want to sync to Asana through SGTM:
 1. Navigate to `https://github.com/<organization>/<repository>/settings/hooks`
 2. Click "Add webhook"
-3. Under "Payload URL", input the `api_gateway_deployment_invoke_url` from the previous step
+3. Under "Payload URL", input the `api_gateway_stage_invoke_url` from the previous step
 4. Under "Content Type", select "application/json"
 5. Under "Secret", input your secret token that you generated earlier
 6. Under "Which events would you like to trigger this webhook?", select "Let me select individual events."

--- a/scripts/create_pkg.sh
+++ b/scripts/create_pkg.sh
@@ -22,7 +22,7 @@ echo "Creating deployment package..."
 
 # install dependencies into a temporary directory other than $dist_dir_name
 # shellcheck disable=SC2154
-temp_dir=tmp"$cluster_suffix"
+temp_dir=tmp"$cluster"
 mkdir -p "$temp_dir"
 pipenv run pip install -r <(pipenv requirements) --platform manylinux2014_x86_64 --only-binary=:all: --target "$temp_dir"
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,8 +2,6 @@ provider "aws" {
   region = var.aws_region
 }
 
-
-
 import {
   to = module.sgtm-prod.aws_cloudwatch_log_group.main
   id = "/aws/lambda/sgtm"
@@ -86,7 +84,7 @@ module "sgtm-prod" {
 
 module "sgtm-staging" {
   source                = "./sgtm-cluster"
-  naming_cluster_suffix = "staging"
+  cluster = "staging"
 
   # API keys retrieval
   api_encryption_key_arn    = aws_kms_key.api_encryption_key.arn
@@ -202,7 +200,7 @@ terraform {
     aws = {
       source = "hashicorp/aws"
       # The lowest version that supports the aws_s3_object attribute.
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "api_gateway_deployment_invoke_url" {
-  value = module.sgtm-prod.api_gateway_deployment_invoke_url
+output "api_gateway_stage_invoke_url" {
+  value = module.sgtm-prod.api_gateway_stage_invoke_url
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,7 @@
-output "api_gateway_stage_invoke_url" {
+output "api_gateway_prod_invoke_url" {
   value = module.sgtm-prod.api_gateway_stage_invoke_url
+}
+
+output "api_gateway_staging_invoke_url" {
+  value = module.sgtm-staging.api_gateway_stage_invoke_url
 }

--- a/terraform/sgtm-cluster/api_gateway_sqs.tf
+++ b/terraform/sgtm-cluster/api_gateway_sqs.tf
@@ -43,7 +43,7 @@ resource "aws_api_gateway_method_response" "proxy" {
 resource "aws_api_gateway_stage" "sgtm_stage" {
   deployment_id = aws_api_gateway_deployment.sgtm_deployment.id
   rest_api_id = var.sgtm_rest_api_id
-  stage_name = var.cluster != null ? "${var.cluster}" : "prod"
+  stage_name = var.cluster != null ? "${var.cluster}" : "default"
 }
 
 output "api_gateway_stage_invoke_url" {

--- a/terraform/sgtm-cluster/lambda_function.tf
+++ b/terraform/sgtm-cluster/lambda_function.tf
@@ -2,7 +2,7 @@
 resource "aws_lambda_function" "sgtm" {
   s3_bucket        = var.lambda_code_s3_bucket_name
   s3_key           = aws_s3_object.lambda_code_bundle.key
-  function_name    = "sgtm${local.cluster_suffix}"
+  function_name    = "sgtm${local.cluster}"
   role             = aws_iam_role.sgtm_lambda.arn
   handler          = "src.handler.handler"
   source_code_hash = data.archive_file.create_dist_pkg.output_base64sha256
@@ -39,7 +39,7 @@ resource "aws_lambda_function" "sgtm" {
 }
 
 locals {
-  dist_dir_name = "lambda_dist_pkg/pkg${local.cluster_suffix}"
+  dist_dir_name = "lambda_dist_pkg/pkg${local.cluster}"
 }
 
 resource "null_resource" "install_python_dependencies" {
@@ -57,7 +57,7 @@ resource "null_resource" "install_python_dependencies" {
       runtime          = var.lambda_runtime
       path_cwd         = path.cwd
       dist_dir_name    = local.dist_dir_name
-      cluster_suffix   = local.cluster_suffix
+      cluster   = local.cluster
     }
   }
 }
@@ -65,7 +65,7 @@ resource "null_resource" "install_python_dependencies" {
 data "archive_file" "create_dist_pkg" {
   depends_on  = [null_resource.install_python_dependencies]
   source_dir  = "${path.cwd}/${local.dist_dir_name}"
-  output_path = "build/pkg${local.cluster_suffix}/function.zip"
+  output_path = "build/pkg${local.cluster}/function.zip"
   type        = "zip"
 }
 
@@ -73,7 +73,7 @@ resource "aws_s3_object" "lambda_code_bundle" {
   ## The lambda code bundle is created by the null_resource.install_python_dependencies
   depends_on  = [null_resource.install_python_dependencies]
   bucket      = var.lambda_code_s3_bucket_name
-  key         = "sgtm_bundle${local.cluster_suffix}.zip"
+  key         = "sgtm_bundle${local.cluster}.zip"
   source      = data.archive_file.create_dist_pkg.output_path
   source_hash = data.archive_file.create_dist_pkg.output_base64sha256
 }

--- a/terraform/sgtm-cluster/lambda_policy.tf
+++ b/terraform/sgtm-cluster/lambda_policy.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "sgtm_lambda" {
-  name               = "sgtm_lambda_role${local.cluster_suffix}"
+  name               = "sgtm_lambda_role${local.cluster}"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -137,7 +137,7 @@ data "aws_iam_policy_document" "sgtm_lambda" {
 
 #### Create a role policy in AWS with the permissions defined in the policy document
 resource "aws_iam_policy" "sgtm_lambda" {
-  name        = "sgtm_lambda_policy${local.cluster_suffix}"
+  name        = "sgtm_lambda_policy${local.cluster}"
   description = "Policy for the SGTM Lambda function"
   policy      = data.aws_iam_policy_document.sgtm_lambda.json
 }
@@ -165,7 +165,7 @@ data "aws_s3_object" "additional_lambda_permissions" {
 
 resource "aws_iam_policy" "additional_lambda_permissions" {
   count  = var.custom_lambda_role_policy_s3_object_key != null ? 1 : 0
-  name   = "${local.cluster_suffix}_additional_lambda_permissions"
+  name   = "${local.cluster}_additional_lambda_permissions"
   policy = data.aws_s3_object.additional_lambda_permissions[0].body
 }
 

--- a/terraform/sgtm-cluster/main.tf
+++ b/terraform/sgtm-cluster/main.tf
@@ -1,5 +1,5 @@
 locals {
-  cluster_suffix = var.naming_cluster_suffix != null ? "_${var.naming_cluster_suffix}" : ""
+  cluster = var.cluster != null ? "_${var.cluster}" : ""
 }
 
 provider "aws" {

--- a/terraform/sgtm-cluster/vars.tf
+++ b/terraform/sgtm-cluster/vars.tf
@@ -24,8 +24,8 @@ variable "api_encryption_key_arn" {
   type        = string
 }
 
-variable "naming_cluster_suffix" {
-  description = "A cluster_suffix to append to the names of resources"
+variable "cluster" {
+  description = "A cluster to define stages and suffix resource names"
   type        = string
   default     = null
 }


### PR DESCRIPTION
### Summary

Our AWS provider was pinned to >= 4.0 and the terraform lock pointed to 5.100. Make a simple change to get up to date terraform aws modules so the syntax drift between this tool and the rest is not substantial

Asana tasks:


Relevant deployment: 

CC: @vn6 @Ongman @FangjianLu @dharmesh-asana @michael-huang87 @ericrafalovsky @yash-asana @harshita-gupta

### Test Plan

- [x] staging deploy works

### Risks





Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1211226908369400)
Pull Request: https://github.com/Asana/SGTM/pull/216