### PR TITLE
Revert "[SGTM UX] ignore bot comments (#203)"

### DIFF
--- a/src/github/controller.py
+++ b/src/github/controller.py
@@ -104,8 +104,7 @@ def upsert_comment(pull_request: PullRequest, comment: Comment, org_name: str):
     pull_request_id = pull_request.id()
     task_id = dynamodb_client.get_asana_id_from_github_node_id(pull_request_id)
     if task_id:
-        if not comment.author().is_bot():
-            asana_controller.upsert_github_comment_to_task(comment, task_id)
+        asana_controller.upsert_github_comment_to_task(comment, task_id)
         # Comments can sometimes post-merge approve a PR, so we requeue a full sync via the "pull_request" event
         if github_logic.is_approval_comment_body(comment.body()):
             sqs_client.queue_full_sync(pull_request_id, org_name)
@@ -124,8 +123,7 @@ def upsert_review(pull_request: PullRequest, review: Review, org_name: str):
             f"Found task id {task_id} for pull_request {pull_request_id}. Adding review"
             " now."
         )
-        if not review.author().is_bot():
-            asana_controller.upsert_github_review_to_task(review, task_id)
+        asana_controller.upsert_github_review_to_task(review, task_id)
         force_update_due_today = False
         if review.is_approval_or_changes_requested():
             # If this action was taken by a user that's marked for follow-up

--- a/src/github/graphql/fragments/FullComment.py
+++ b/src/github/graphql/fragments/FullComment.py
@@ -18,7 +18,6 @@ fragment FullComment on Comment {
   __typename
   id
   author {
-    __typename
     login
     ... on User {
       name

--- a/src/github/graphql/fragments/FullReview.py
+++ b/src/github/graphql/fragments/FullReview.py
@@ -6,7 +6,6 @@ _full_review = """
 fragment FullReview on PullRequestReview {
   id
   author {
-    __typename
     login
     ... on User {
       name

--- a/src/github/models/user.py
+++ b/src/github/models/user.py
@@ -11,9 +11,6 @@ class User(object):
     def id(self) -> str:
         return self._raw["id"]
 
-    def is_bot(self) -> bool:
-        return self._raw["__typename"] == "Bot"
-
     def login(self) -> str:
         return self._raw["login"]
 

--- a/test/github/test_controller.py
+++ b/test/github/test_controller.py
@@ -6,7 +6,6 @@ import src.aws.dynamodb_client as dynamodb_client
 import src.aws.sqs_client as sqs_client
 import src.github.client as github_client
 import src.github.controller as github_controller
-from src.github.models import ReviewState
 from test.impl.builders import builder
 from test.impl.mock_dynamodb_test_case import MockDynamoDbTestCase
 
@@ -90,8 +89,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         # If the task id is found in dynamodb, then we just update (don't
         # attempt to create)
         pull_request = builder.pull_request().build()
-        user = builder.user().login("the_author").name("dont-care")
-        comment = builder.comment().author(user).build()
+        comment = builder.comment().build()
         org_name = "the-org"
 
         # Insert the mapping first
@@ -114,8 +112,7 @@ class GithubControllerTest(MockDynamoDbTestCase):
         # If the task id is found in dynamodb, then we just update (don't
         # attempt to create)
         pull_request = builder.pull_request().build()
-        user = builder.user().login("the_author").name("dont-care")
-        comment = builder.comment("LGTM").author(user).build()
+        comment = builder.comment("LGTM").build()
         org_name = "the-org"
 
         # Insert the mapping first
@@ -137,63 +134,12 @@ class GithubControllerTest(MockDynamoDbTestCase):
         _get_asana_domain_id_mock,
     ):
         pull_request = builder.pull_request().build()
-        user = builder.user().login("the_author").name("dont-care")
-        comment = builder.comment().author(user).build()
+        comment = builder.comment().build()
         org_name = "the-org"
 
         github_controller.upsert_comment(pull_request, comment, org_name)
         add_comment_mock.assert_not_called()
         queue_mock.assert_called_with(pull_request.id(), org_name)
-
-    @patch.object(asana_controller, "upsert_github_comment_to_task")
-    def test_no_comment_when_made_by_bot(
-        self,
-        add_comment_mock,
-        _get_asana_domain_id_mock,
-    ):
-        pull_request = builder.pull_request().build()
-        bot_user = builder.user().login("the_author")
-        comment = builder.comment("Blah").author(bot_user).build()
-
-        # Insert the mapping first
-        existing_task_id = uuid4().hex
-        dynamodb_client.insert_github_node_to_asana_id_mapping(
-            pull_request.id(), existing_task_id
-        )
-
-        github_controller.upsert_comment(pull_request, comment, org_name="organization")
-        add_comment_mock.assert_not_called()
-
-    @patch.object(asana_controller, "update_task")
-    @patch.object(asana_controller, "upsert_github_review_to_task")
-    @patch.object(github_client, "set_pull_request_assignee")
-    def test_no_review_comment_when_made_by_bot(
-        self,
-        set_assignee_mock,
-        add_review_mock,
-        update_task_mock,
-        _get_asana_domain_id_mock,
-    ):
-        author = builder.user().login("the_author").name("not-a-bot")
-        pull_request = builder.pull_request().author(author).build()
-        bot = builder.user().login("the_bot")
-        review = builder.review("LGTM").author(bot).state(ReviewState.APPROVED).build()
-        org_name = "the-org"
-
-        # Insert the mapping first
-        existing_task_id = uuid4().hex
-        dynamodb_client.insert_github_node_to_asana_id_mapping(
-            pull_request.id(), existing_task_id
-        )
-
-        github_controller.upsert_review(pull_request, review, org_name)
-        add_review_mock.assert_not_called()
-        set_assignee_mock.assert_called_with(
-            pull_request.repository_owner_handle(),
-            pull_request.repository_name(),
-            pull_request.number(),
-            pull_request.author_handle(),
-        )
 
     @patch.object(github_client, "set_pull_request_assignee")
     def test_assign_pull_request_to_author(

--- a/test/impl/builders/user_builder.py
+++ b/test/impl/builders/user_builder.py
@@ -7,15 +7,10 @@ from .builder_base_class import BuilderBaseClass
 class UserBuilder(BuilderBaseClass):
     LOGIN_COUNTER = 0
 
-    def __init__(self, login: Optional[str] = None, name: Optional[str] = None):
+    def __init__(self, login: Optional[str] = None, name: str = ""):
         if login is None:
             login = UserBuilder.next_login()
-        self.raw_user = {
-            "__typename": "Bot" if name is None else "User",
-            "id": create_uuid(),
-            "login": login,
-            "name": name,
-        }
+        self.raw_user = {"id": create_uuid(), "login": login, "name": name}
 
     @staticmethod
     def next_login():
@@ -29,7 +24,6 @@ class UserBuilder(BuilderBaseClass):
 
     def name(self, name: str):
         self.raw_user["name"] = name
-        self.raw_user["__typename"] = "User"
         return self
 
     def build(self) -> User:


### PR DESCRIPTION
This reverts commit d9a2010e2e6bcfa31c5c12faf5cee03f76f153dd.

We have found that on balance, it's better to have bot comments synced to tasks so people don't miss them. Given this, revert the commit that started ignoring them.


Pull Request synchronized with [Asana task](https://app.asana.com/0/0/1214017152548601)
Pull Request: https://github.com/Asana/SGTM/pull/222