### PR TITLE
Sanitize raw HTML in bot comments instead of escaping

### DIFF
--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -60,12 +60,27 @@ class _AsanaHTMLSanitizer(HTMLParser):
     - Validates URL schemes (only http/https/mailto allowed)
     """
 
+    # Tags whose boundaries deserve a visible separator so that adjacent
+    # cell text doesn't run together (e.g. "<td>A</td><td>B</td>" → "A | B").
+    _TABLE_CELL_TAGS = frozenset({"td", "th"})
+    _TABLE_ROW_TAG = "tr"
+
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list = []
+        self._cell_count_in_row = 0  # tracks cell position within a <tr>
 
     def handle_starttag(self, tag: str, attrs: list) -> None:
         tag_lower = tag.lower()
+        # Table structure: insert separators so cell text doesn't run together.
+        if tag_lower in self._TABLE_CELL_TAGS:
+            if self._cell_count_in_row > 0:
+                self._parts.append(" | ")
+            self._cell_count_in_row += 1
+            return
+        if tag_lower == self._TABLE_ROW_TAG:
+            self._cell_count_in_row = 0
+            return
         if tag_lower in _ASANA_SUPPORTED_TAGS:
             allowed = _ASANA_ALLOWED_ATTRS.get(tag_lower, frozenset())
             safe_attrs = []
@@ -96,8 +111,15 @@ class _AsanaHTMLSanitizer(HTMLParser):
         # silently strip the tag; text content is preserved via handle_data.
 
     def handle_endtag(self, tag: str) -> None:
-        if tag.lower() in _ASANA_SUPPORTED_TAGS:
-            self._parts.append(f"</{tag.lower()}>")
+        tag_lower = tag.lower()
+        if tag_lower == self._TABLE_ROW_TAG:
+            self._parts.append("\n")
+            self._cell_count_in_row = 0
+            return
+        if tag_lower in self._TABLE_CELL_TAGS:
+            return  # closing </td>/</th> needs no output
+        if tag_lower in _ASANA_SUPPORTED_TAGS:
+            self._parts.append(f"</{tag_lower}>")
 
     def handle_data(self, data: str) -> None:
         self._parts.append(escape(data, quote=False))

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -35,6 +35,18 @@ _ASANA_ALLOWED_ATTRS = {
     "a": frozenset({"href", "data-asana-gid", "data-asana-dynamic"}),
 }
 
+# URL schemes considered safe for href/src attributes.
+_SAFE_URL_SCHEMES = frozenset({"http", "https", "mailto"})
+
+
+def _is_safe_url(url: str) -> bool:
+    """Check that a URL uses a safe scheme (http, https, mailto)."""
+    try:
+        parsed = urlparse(url)
+        return parsed.scheme.lower() in _SAFE_URL_SCHEMES
+    except Exception:
+        return False
+
 
 class _AsanaHTMLSanitizer(HTMLParser):
     """Sanitizes raw HTML for Asana's rich text API.
@@ -45,6 +57,7 @@ class _AsanaHTMLSanitizer(HTMLParser):
     - Converts <br> to newlines
     - Passes through <hr />
     - Removes HTML comments entirely
+    - Validates URL schemes (only http/https/mailto allowed)
     """
 
     def __init__(self) -> None:
@@ -56,16 +69,22 @@ class _AsanaHTMLSanitizer(HTMLParser):
         if tag_lower in _ASANA_SUPPORTED_TAGS:
             allowed = _ASANA_ALLOWED_ATTRS.get(tag_lower, frozenset())
             safe_attrs = []
+            seen_keys = set()
             for k, v in attrs:
-                if k.lower() in allowed and v is not None:
+                k_lower = k.lower()
+                if k_lower in allowed and k_lower not in seen_keys and v is not None:
+                    # Validate URL attributes against safe schemes
+                    if k_lower == "href" and not _is_safe_url(v):
+                        continue
                     safe_attrs.append(f'{k}="{escape(v)}"')
+                    seen_keys.add(k_lower)
             attr_str = (" " + " ".join(safe_attrs)) if safe_attrs else ""
             self._parts.append(f"<{tag_lower}{attr_str}>")
         elif tag_lower == "img":
             attrs_dict = dict(attrs)
             src = attrs_dict.get("src", "")
             alt = attrs_dict.get("alt", "")
-            if src:
+            if src and _is_safe_url(src):
                 self._parts.append(
                     f'<a href="{escape(src)}">{escape(alt or src)}</a>'
                 )

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -63,9 +63,32 @@ _BLOCK_LEVEL_TAGS = frozenset(
     }
 )
 
-# Regex to detect HTML tags in text (used to distinguish indented HTML from
-# genuine code blocks).
-_HTML_TAG_RE = re.compile(r"<[a-zA-Z][^>]*>")
+# Known HTML tag names, used to distinguish indented bot HTML from genuine
+# code blocks.  A simple regex like `<[a-zA-Z]...>` would false-positive on
+# C++ templates (vector<int>), angle-bracket strings, etc.  Checking against
+# actual HTML tag names avoids those cases.
+_KNOWN_HTML_TAG_NAMES = frozenset(
+    {
+        "a", "abbr", "article", "aside", "b", "blockquote", "br", "button",
+        "caption", "code", "col", "colgroup", "dd", "del", "details", "div",
+        "dl", "dt", "em", "figcaption", "figure", "footer", "form",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "header", "hr", "i", "iframe", "img", "input", "ins", "label", "li",
+        "main", "nav", "ol", "option", "p", "picture", "pre", "s", "section",
+        "select", "source", "span", "strong", "sub", "summary", "sup",
+        "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "tr",
+        "u", "ul", "video",
+    }
+)
+_TAG_NAME_RE = re.compile(r"<([a-zA-Z][a-zA-Z0-9]*)")
+
+
+def _contains_html_tags(text: str) -> bool:
+    """Return True if *text* contains what looks like a known HTML tag."""
+    for m in _TAG_NAME_RE.finditer(text):
+        if m.group(1).lower() in _KNOWN_HTML_TAG_NAMES:
+            return True
+    return False
 
 
 def _urlreplace(matchobj: Match[str]) -> str:
@@ -226,7 +249,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         # Indented code blocks (info=None) that contain HTML tags are likely
         # bot comments with cosmetic leading whitespace, not actual code —
         # sanitize them instead of rendering as <pre>.
-        if info is None and _HTML_TAG_RE.search(code):
+        if info is None and _contains_html_tags(code):
             return sanitize_html_for_asana(code)
         return "<pre>" + escape(code) + "</pre>"
 

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -38,6 +38,42 @@ _ASANA_ALLOWED_ATTRS = {
 # URL schemes considered safe for href/src attributes.
 _SAFE_URL_SCHEMES = frozenset({"http", "https", "mailto"})
 
+# Block-level HTML elements that should emit a newline when their closing tag
+# is stripped, so adjacent blocks don't run together (e.g. "TitleBody" → "Title\nBody").
+_BLOCK_LEVEL_TAGS = frozenset(
+    {
+        "p",
+        "div",
+        "section",
+        "summary",
+        "details",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "footer",
+        "nav",
+        "article",
+        "aside",
+        "figure",
+        "figcaption",
+    }
+)
+
+# Regex to detect HTML tags in text (used to distinguish indented HTML from
+# genuine code blocks).
+_HTML_TAG_RE = re.compile(r"<[a-zA-Z][^>]*>")
+
+
+def _urlreplace(matchobj: Match[str]) -> str:
+    """Replace a bare URL match with an <a> tag. Used by both the markdown
+    renderer's text() method and the HTML sanitizer's handle_data()."""
+    url = unescape(matchobj.group(2))
+    return matchobj.group(1) + f'<a href="{escape(url, quote=False)}">{url}</a>'
+
 
 def _is_safe_url(url: str) -> bool:
     """Check that a URL uses a safe scheme (http, https, mailto)."""
@@ -120,9 +156,15 @@ class _AsanaHTMLSanitizer(HTMLParser):
             return  # closing </td>/</th> needs no output
         if tag_lower in _ASANA_SUPPORTED_TAGS:
             self._parts.append(f"</{tag_lower}>")
+        elif tag_lower in _BLOCK_LEVEL_TAGS:
+            self._parts.append("\n")
 
     def handle_data(self, data: str) -> None:
-        self._parts.append(escape(data, quote=False))
+        text = escape(data, quote=False)
+        # Auto-link bare URLs, matching the behavior of the markdown
+        # renderer's text() method.
+        text = re.sub(URL_REGEX, _urlreplace, text)
+        self._parts.append(text)
 
     def handle_entityref(self, name: str) -> None:
         self._parts.append(f"&{name};")
@@ -180,16 +222,17 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     def block_code(self, code, info=None):
         #  Strip the '\r\n' from the end of the code text that Github automatically adds
         code = code.rstrip("\r\n")
+        # Fenced code blocks (info is set, e.g. ```python) are always real code.
+        # Indented code blocks (info=None) that contain HTML tags are likely
+        # bot comments with cosmetic leading whitespace, not actual code —
+        # sanitize them instead of rendering as <pre>.
+        if info is None and _HTML_TAG_RE.search(code):
+            return sanitize_html_for_asana(code)
         return "<pre>" + escape(code) + "</pre>"
 
     def text(self, text) -> str:
         text = escape(text, quote=False)
-
-        def urlreplace(matchobj: Match[str]) -> str:
-            url = unescape(matchobj.group(2))
-            return matchobj.group(1) + f'<a href="{escape(url, quote=False)}">{url}</a>'
-
-        return re.sub(URL_REGEX, urlreplace, text)
+        return re.sub(URL_REGEX, _urlreplace, text)
 
     def link(self, link, text=None, title=None):
         # the parser may pass in `title`, but Asana's API does not allow the
@@ -200,7 +243,7 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         asana_tags = 'data-asana-dynamic="false" ' if is_asana_vanity_link else ""
 
         safe_url = self._safe_url(link)
-        if self._is_valid_url(safe_url):
+        if _is_safe_url(safe_url):
             return f'<a {asana_tags}href="{safe_url}">{text or safe_url}</a>'
         else:
             return escape(text or safe_url, quote=False)
@@ -208,14 +251,6 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     # Asana's API can't handle img tags
     def image(self, src, alt="", title=None) -> str:
         return self.link(src, text=alt, title=title)
-
-    def _is_valid_url(self, url: str) -> bool:
-        try:
-            result = urlparse(url)
-            return all([result.scheme, result.netloc])
-        except:
-            # invalid URL
-            return False
 
 
 def convert_github_markdown_to_asana_xml(text: str) -> str:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -38,6 +38,11 @@ _ASANA_ALLOWED_ATTRS = {
 # URL schemes considered safe for href/src attributes.
 _SAFE_URL_SCHEMES = frozenset({"http", "https", "mailto"})
 
+# Table cell/row tags get special treatment: " | " between cells, "\n" at row
+# boundaries, so stripped table text doesn't run together.
+_TABLE_CELL_TAGS = frozenset({"td", "th"})
+_TABLE_ROW_TAG = "tr"
+
 # Block-level HTML elements that should emit a newline when their closing tag
 # is stripped, so adjacent blocks don't run together (e.g. "TitleBody" → "Title\nBody").
 _BLOCK_LEVEL_TAGS = frozenset(
@@ -119,11 +124,6 @@ class _AsanaHTMLSanitizer(HTMLParser):
     - Validates URL schemes (only http/https/mailto allowed)
     """
 
-    # Tags whose boundaries deserve a visible separator so that adjacent
-    # cell text doesn't run together (e.g. "<td>A</td><td>B</td>" → "A | B").
-    _TABLE_CELL_TAGS = frozenset({"td", "th"})
-    _TABLE_ROW_TAG = "tr"
-
     def __init__(self) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list = []
@@ -132,12 +132,12 @@ class _AsanaHTMLSanitizer(HTMLParser):
     def handle_starttag(self, tag: str, attrs: list) -> None:
         tag_lower = tag.lower()
         # Table structure: insert separators so cell text doesn't run together.
-        if tag_lower in self._TABLE_CELL_TAGS:
+        if tag_lower in _TABLE_CELL_TAGS:
             if self._cell_count_in_row > 0:
                 self._parts.append(" | ")
             self._cell_count_in_row += 1
             return
-        if tag_lower == self._TABLE_ROW_TAG:
+        if tag_lower == _TABLE_ROW_TAG:
             self._cell_count_in_row = 0
             return
         if tag_lower in _ASANA_SUPPORTED_TAGS:
@@ -171,16 +171,19 @@ class _AsanaHTMLSanitizer(HTMLParser):
 
     def handle_endtag(self, tag: str) -> None:
         tag_lower = tag.lower()
-        if tag_lower == self._TABLE_ROW_TAG:
+        if tag_lower == _TABLE_ROW_TAG:
             self._parts.append("\n")
             self._cell_count_in_row = 0
             return
-        if tag_lower in self._TABLE_CELL_TAGS:
+        if tag_lower in _TABLE_CELL_TAGS:
             return  # closing </td>/</th> needs no output
         if tag_lower in _ASANA_SUPPORTED_TAGS:
             self._parts.append(f"</{tag_lower}>")
         elif tag_lower in _BLOCK_LEVEL_TAGS:
-            self._parts.append("\n")
+            # Avoid consecutive newlines from deeply nested block elements
+            # (e.g. </p></div></div> should not emit three newlines).
+            if not self._parts or not self._parts[-1].endswith("\n"):
+                self._parts.append("\n")
 
     def handle_data(self, data: str) -> None:
         text = escape(data, quote=False)

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -1,5 +1,6 @@
 import re
 from html import escape, unescape
+from html.parser import HTMLParser
 from typing import Match
 from urllib.parse import urlparse
 
@@ -7,6 +8,104 @@ import mistune  # type: ignore
 
 # https://gist.github.com/gruber/8891611
 URL_REGEX = r"""(?i)([^"\>\<\/\.]|^)\b((?:https?:(/{1,3}))(?:[^\s()<>{}\[\]]+|\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\))+(?:\([^\s()]*?\([^\s()]+\)[^\s()]*?\)|\([^\s]+?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))"""
+
+
+# Tags that Asana's rich text API supports.
+# https://developers.asana.com/docs/rich-text
+_ASANA_SUPPORTED_TAGS = frozenset(
+    {
+        "a",
+        "b",
+        "strong",
+        "em",
+        "i",
+        "s",
+        "u",
+        "code",
+        "pre",
+        "ol",
+        "ul",
+        "li",
+        "blockquote",
+    }
+)
+
+# Per-tag allowlist of HTML attributes that Asana accepts.
+_ASANA_ALLOWED_ATTRS = {
+    "a": frozenset({"href", "data-asana-gid", "data-asana-dynamic"}),
+}
+
+
+class _AsanaHTMLSanitizer(HTMLParser):
+    """Sanitizes raw HTML for Asana's rich text API.
+
+    - Passes through Asana-supported tags with sanitized attributes
+    - Strips unsupported wrapper tags but preserves their text content
+    - Converts <img> tags to <a> links using src/alt attributes
+    - Converts <br> to newlines
+    - Passes through <hr />
+    - Removes HTML comments entirely
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=False)
+        self._parts: list = []
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        tag_lower = tag.lower()
+        if tag_lower in _ASANA_SUPPORTED_TAGS:
+            allowed = _ASANA_ALLOWED_ATTRS.get(tag_lower, frozenset())
+            safe_attrs = []
+            for k, v in attrs:
+                if k.lower() in allowed and v is not None:
+                    safe_attrs.append(f'{k}="{escape(v)}"')
+            attr_str = (" " + " ".join(safe_attrs)) if safe_attrs else ""
+            self._parts.append(f"<{tag_lower}{attr_str}>")
+        elif tag_lower == "img":
+            attrs_dict = dict(attrs)
+            src = attrs_dict.get("src", "")
+            alt = attrs_dict.get("alt", "")
+            if src:
+                self._parts.append(
+                    f'<a href="{escape(src)}">{escape(alt or src)}</a>'
+                )
+        elif tag_lower == "br":
+            self._parts.append("\n")
+        elif tag_lower == "hr":
+            self._parts.append("<hr />")
+        # All other tags (details, summary, div, table, h1-h6, etc.):
+        # silently strip the tag; text content is preserved via handle_data.
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() in _ASANA_SUPPORTED_TAGS:
+            self._parts.append(f"</{tag.lower()}>")
+
+    def handle_data(self, data: str) -> None:
+        self._parts.append(escape(data, quote=False))
+
+    def handle_entityref(self, name: str) -> None:
+        self._parts.append(f"&{name};")
+
+    def handle_charref(self, name: str) -> None:
+        self._parts.append(f"&#{name};")
+
+    def handle_comment(self, data: str) -> None:
+        pass  # Strip HTML comments entirely
+
+    def get_result(self) -> str:
+        return "".join(self._parts)
+
+
+def sanitize_html_for_asana(html: str) -> str:
+    """Sanitize raw HTML for Asana's rich text API.
+
+    Converts a block of raw HTML (e.g. from a GitHub bot comment) into
+    Asana-compatible markup by keeping supported tags, stripping unsupported
+    wrapper tags while preserving their text, and removing HTML comments.
+    """
+    sanitizer = _AsanaHTMLSanitizer()
+    sanitizer.feed(html)
+    return sanitizer.get_result()
 
 
 class GithubToAsanaRenderer(mistune.HTMLRenderer):
@@ -26,10 +125,10 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return "<hr />"
 
     def inline_html(self, html) -> str:
-        return escape(html)
+        return sanitize_html_for_asana(html)
 
     def block_html(self, html) -> str:
-        return escape(html)
+        return sanitize_html_for_asana(html)
 
     def linebreak(self) -> str:
         return "\n"

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -266,6 +266,47 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         html = "before<!-- multi\nline\ncomment -->after"
         self.assertEqual(sanitize_html_for_asana(html), "beforeafter")
 
+    # --- URL scheme validation ---
+
+    def test_blocks_javascript_url_in_href(self):
+        html = '<a href="javascript:alert(1)">click</a>'
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("javascript:", result)
+        # Tag still emitted but without href
+        self.assertIn("<a>", result)
+
+    def test_blocks_data_url_in_href(self):
+        html = '<a href="data:text/html,payload">click</a>'
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("data:", result)
+
+    def test_blocks_javascript_url_in_img_src(self):
+        html = '<img src="javascript:alert(1)" alt="xss" />'
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("javascript:", result)
+        self.assertEqual(result, "")
+
+    def test_allows_https_url_in_href(self):
+        html = '<a href="https://example.com">link</a>'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="https://example.com">link</a>',
+        )
+
+    def test_allows_mailto_url_in_href(self):
+        html = '<a href="mailto:user@example.com">email</a>'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="mailto:user@example.com">email</a>',
+        )
+
+    def test_deduplicates_href_attributes(self):
+        """Only the first href is kept if an element has duplicates."""
+        html = '<a href="https://first.com" href="https://second.com">link</a>'
+        result = sanitize_html_for_asana(html)
+        self.assertIn("https://first.com", result)
+        self.assertNotIn("https://second.com", result)
+
     # --- Text escaping ---
 
     def test_escapes_special_chars_in_text(self):

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,7 +1,7 @@
 import unittest
 
 from html import escape
-from src.markdown_parser import convert_github_markdown_to_asana_xml
+from src.markdown_parser import convert_github_markdown_to_asana_xml, sanitize_html_for_asana
 
 
 class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
@@ -109,43 +109,250 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, "<code>test</code>\n")
 
-    def test_escapes_raw_html_mixed_with_markdown(self):
+    def test_sanitizes_raw_html_mixed_with_markdown(self):
+        """Unsupported tags are stripped but content preserved inside markdown."""
         md = """## <img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(
-            xml,
-            "\n<b>"
-            + escape('<img href="link" />')
-            + "still here "
-            + escape("<h3>header</h3>")
-            + "</b>\n",
-        )
+        # <img> without src is stripped; <h3> tags stripped, content kept
+        self.assertEqual(xml, "\n<b>still here header</b>\n")
 
-    def test_escapes_raw_html_on_own_lines(self):
+    def test_sanitizes_raw_html_on_own_lines(self):
+        """Block-level raw HTML is sanitized, not escaped."""
         md = """## blah blah blah
 <img href="link">
 still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
-            "\n<b>blah blah blah</b>\n"
-            + escape('<img href="link">\n')
-            + "still here "
-            + escape("<h3>header</h3>"),
+            "\n<b>blah blah blah</b>\n" + "\n" + "still here header",
         )
 
-    def test_escapes_raw_html(self):
+    def test_sanitizes_raw_html(self):
+        """Inline raw HTML tags are sanitized: unsupported stripped, content kept."""
         md = """<img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(
-            xml,
-            escape('<img href="link" />') + "still here " + escape("<h3>header</h3>\n"),
-        )
+        self.assertEqual(xml, "still here header\n")
 
     def test_removes_images(self):
         md = """![image](https://image.com)"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(xml, '<a href="https://image.com">image</a>\n')
+
+
+class TestSanitizeHtmlForAsana(unittest.TestCase):
+    """Tests for the HTML sanitizer that converts raw HTML to Asana-compatible markup."""
+
+    # --- Asana-supported tags pass through ---
+
+    def test_preserves_anchor_tag_with_href(self):
+        html = '<a href="https://example.com">click here</a>'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="https://example.com">click here</a>',
+        )
+
+    def test_strips_unsupported_attrs_from_anchor(self):
+        html = '<a href="https://example.com" target="_blank" rel="noopener">link</a>'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="https://example.com">link</a>',
+        )
+
+    def test_preserves_bold_tags(self):
+        self.assertEqual(
+            sanitize_html_for_asana("<b>bold</b>"),
+            "<b>bold</b>",
+        )
+        self.assertEqual(
+            sanitize_html_for_asana("<strong>bold</strong>"),
+            "<strong>bold</strong>",
+        )
+
+    def test_preserves_emphasis_tags(self):
+        self.assertEqual(
+            sanitize_html_for_asana("<em>italic</em>"),
+            "<em>italic</em>",
+        )
+        self.assertEqual(
+            sanitize_html_for_asana("<i>italic</i>"),
+            "<i>italic</i>",
+        )
+
+    def test_preserves_list_tags(self):
+        html = "<ul><li>one</li><li>two</li></ul>"
+        self.assertEqual(sanitize_html_for_asana(html), html)
+
+    def test_preserves_code_tags(self):
+        self.assertEqual(
+            sanitize_html_for_asana("<code>foo()</code>"),
+            "<code>foo()</code>",
+        )
+        self.assertEqual(
+            sanitize_html_for_asana("<pre>block</pre>"),
+            "<pre>block</pre>",
+        )
+
+    def test_preserves_strikethrough_and_underline(self):
+        self.assertEqual(sanitize_html_for_asana("<s>old</s>"), "<s>old</s>")
+        self.assertEqual(sanitize_html_for_asana("<u>new</u>"), "<u>new</u>")
+
+    def test_preserves_blockquote(self):
+        self.assertEqual(
+            sanitize_html_for_asana("<blockquote>quoted</blockquote>"),
+            "<blockquote>quoted</blockquote>",
+        )
+
+    # --- Unsupported tags stripped, content preserved ---
+
+    def test_strips_details_summary(self):
+        html = "<details><summary>Click to expand</summary>Hidden content</details>"
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            "Click to expandHidden content",
+        )
+
+    def test_strips_div_span(self):
+        html = '<div class="wrapper"><span>text</span></div>'
+        self.assertEqual(sanitize_html_for_asana(html), "text")
+
+    def test_strips_heading_tags(self):
+        for level in range(1, 7):
+            html = f"<h{level}>Heading</h{level}>"
+            self.assertEqual(sanitize_html_for_asana(html), "Heading")
+
+    def test_strips_table_tags_preserves_text(self):
+        html = "<table><tr><th>Name</th><th>Status</th></tr><tr><td>foo</td><td>OK</td></tr></table>"
+        self.assertEqual(sanitize_html_for_asana(html), "NameStatusfooOK")
+
+    def test_strips_p_tags(self):
+        html = "<p>paragraph text</p>"
+        self.assertEqual(sanitize_html_for_asana(html), "paragraph text")
+
+    # --- Special tag conversions ---
+
+    def test_converts_img_with_src_to_link(self):
+        html = '<img src="https://example.com/image.png" alt="Logo" />'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="https://example.com/image.png">Logo</a>',
+        )
+
+    def test_converts_img_without_alt_uses_src(self):
+        html = '<img src="https://example.com/pic.png" />'
+        self.assertEqual(
+            sanitize_html_for_asana(html),
+            '<a href="https://example.com/pic.png">https://example.com/pic.png</a>',
+        )
+
+    def test_strips_img_without_src(self):
+        html = '<img alt="no source" />'
+        self.assertEqual(sanitize_html_for_asana(html), "")
+
+    def test_converts_br_to_newline(self):
+        self.assertEqual(sanitize_html_for_asana("line1<br>line2"), "line1\nline2")
+        self.assertEqual(sanitize_html_for_asana("line1<br />line2"), "line1\nline2")
+
+    def test_passes_through_hr(self):
+        self.assertEqual(sanitize_html_for_asana("<hr>"), "<hr />")
+        self.assertEqual(sanitize_html_for_asana("<hr />"), "<hr />")
+
+    # --- HTML comments ---
+
+    def test_strips_html_comments(self):
+        html = "<!-- this is a comment -->visible text"
+        self.assertEqual(sanitize_html_for_asana(html), "visible text")
+
+    def test_strips_multiline_html_comments(self):
+        html = "before<!-- multi\nline\ncomment -->after"
+        self.assertEqual(sanitize_html_for_asana(html), "beforeafter")
+
+    # --- Text escaping ---
+
+    def test_escapes_special_chars_in_text(self):
+        html = "<div>1 < 2 & 3 > 0</div>"
+        result = sanitize_html_for_asana(html)
+        self.assertIn("1 &lt; 2 &amp; 3 &gt; 0", result)
+
+    def test_preserves_entity_refs(self):
+        html = "&amp; &lt; &gt;"
+        self.assertEqual(sanitize_html_for_asana(html), "&amp; &lt; &gt;")
+
+    # --- Real-world bot comment patterns ---
+
+    def test_spacelift_comment(self):
+        """Spacelift-style collapsible status with nested list and links."""
+        html = (
+            "<!-- spacelift_id -->"
+            "Commit: abc123\n"
+            "<details><summary>Stacks affected:</summary>"
+            '<ul><li>stack-a: <a href="https://spacelift.io/a">link</a></li></ul>'
+            "</details>"
+        )
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("<!--", result)
+        self.assertNotIn("<details>", result)
+        self.assertNotIn("<summary>", result)
+        self.assertIn("Commit: abc123", result)
+        self.assertIn("Stacks affected:", result)
+        self.assertIn("<ul>", result)
+        self.assertIn("<li>", result)
+        self.assertIn('<a href="https://spacelift.io/a">link</a>', result)
+
+    def test_graphite_comment(self):
+        """Graphite-style comment with images and styled links."""
+        html = (
+            '<a href="https://graphite.dev" target="_blank">'
+            '<img src="https://graphite.dev/logo.png" alt="Graphite" width="10" />'
+            "</a> "
+            '<a href="https://graphite.dev"><b>Graphite</b></a>'
+        )
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("target=", result)
+        self.assertNotIn("<img", result)
+        self.assertIn('<a href="https://graphite.dev">', result)
+        self.assertIn("<b>Graphite</b>", result)
+
+    def test_cursor_agent_badges(self):
+        """Cursor agent badge HTML with picture/source/div elements."""
+        html = (
+            '<div><a href="https://cursor.com/agent">'
+            "<picture>"
+            '<source media="(prefers-color-scheme: dark)" srcset="dark.png">'
+            '<img alt="Open" src="light.png">'
+            "</picture></a></div>"
+        )
+        result = sanitize_html_for_asana(html)
+        self.assertNotIn("<div>", result)
+        self.assertNotIn("<picture>", result)
+        self.assertNotIn("<source", result)
+        self.assertIn('<a href="https://cursor.com/agent">', result)
+
+    # --- End-to-end through the markdown parser ---
+
+    def test_markdown_with_details_block(self):
+        """GitHub markdown containing a <details> block renders cleanly."""
+        md = "Summary\n\n<details><summary>Details</summary>\n\nHidden\n\n</details>"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertNotIn("&lt;details&gt;", xml)
+        self.assertNotIn("&lt;summary&gt;", xml)
+        self.assertIn("Summary", xml)
+        self.assertIn("Details", xml)
+        self.assertIn("Hidden", xml)
+
+    def test_markdown_with_html_comment(self):
+        """HTML comments in markdown are stripped entirely."""
+        md = "<!-- hidden -->visible text"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertNotIn("<!--", xml)
+        self.assertNotIn("hidden", xml)
+        self.assertIn("visible text", xml)
+
+    def test_markdown_with_inline_html_link(self):
+        """Raw <a> tags in markdown pass through with sanitized attributes."""
+        md = 'Click <a href="https://example.com" target="_blank">here</a> now'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertIn('<a href="https://example.com">here</a>', xml)
+        self.assertNotIn("target=", xml)
 
 
 if __name__ == "__main__":

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -113,8 +113,8 @@ class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
         """Unsupported tags are stripped but content preserved inside markdown."""
         md = """## <img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        # <img> without src is stripped; <h3> tags stripped, content kept
-        self.assertEqual(xml, "\n<b>still here header</b>\n")
+        # <img> without src is stripped; <h3> tags stripped with block newline
+        self.assertEqual(xml, "\n<b>still here header\n</b>\n")
 
     def test_sanitizes_raw_html_on_own_lines(self):
         """Block-level raw HTML is sanitized, not escaped."""
@@ -124,14 +124,14 @@ still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertEqual(
             xml,
-            "\n<b>blah blah blah</b>\n" + "\n" + "still here header",
+            "\n<b>blah blah blah</b>\n" + "\n" + "still here header\n",
         )
 
     def test_sanitizes_raw_html(self):
         """Inline raw HTML tags are sanitized: unsupported stripped, content kept."""
         md = """<img href="link" />still here <h3>header</h3>"""
         xml = convert_github_markdown_to_asana_xml(md)
-        self.assertEqual(xml, "still here header\n")
+        self.assertEqual(xml, "still here header\n\n")
 
     def test_removes_images(self):
         md = """![image](https://image.com)"""
@@ -204,21 +204,21 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
 
     # --- Unsupported tags stripped, content preserved ---
 
-    def test_strips_details_summary(self):
+    def test_strips_details_summary_with_newlines(self):
         html = "<details><summary>Click to expand</summary>Hidden content</details>"
         self.assertEqual(
             sanitize_html_for_asana(html),
-            "Click to expandHidden content",
+            "Click to expand\nHidden content\n",
         )
 
-    def test_strips_div_span(self):
+    def test_strips_div_with_newline(self):
         html = '<div class="wrapper"><span>text</span></div>'
-        self.assertEqual(sanitize_html_for_asana(html), "text")
+        self.assertEqual(sanitize_html_for_asana(html), "text\n")
 
-    def test_strips_heading_tags(self):
+    def test_strips_heading_tags_with_newlines(self):
         for level in range(1, 7):
             html = f"<h{level}>Heading</h{level}>"
-            self.assertEqual(sanitize_html_for_asana(html), "Heading")
+            self.assertEqual(sanitize_html_for_asana(html), "Heading\n")
 
     def test_strips_table_tags_preserves_text_with_separators(self):
         html = "<table><tr><th>Name</th><th>Status</th></tr><tr><td>foo</td><td>OK</td></tr></table>"
@@ -234,9 +234,9 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         html = "<table><tr><td>A</td><td>B</td><td>C</td></tr></table>"
         self.assertEqual(sanitize_html_for_asana(html), "A | B | C\n")
 
-    def test_strips_p_tags(self):
+    def test_strips_p_tags_with_newline(self):
         html = "<p>paragraph text</p>"
-        self.assertEqual(sanitize_html_for_asana(html), "paragraph text")
+        self.assertEqual(sanitize_html_for_asana(html), "paragraph text\n")
 
     # --- Special tag conversions ---
 
@@ -404,6 +404,62 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertIn('<a href="https://example.com">here</a>', xml)
         self.assertNotIn("target=", xml)
+
+    def test_indented_html_is_sanitized_not_code_blocked(self):
+        """Indented HTML (common in bot comments) is sanitized, not treated as <pre>."""
+        md = '        #123 <a href="https://graphite.dev" target="_blank">View</a>\n\n        next-master\n'
+        xml = convert_github_markdown_to_asana_xml(md)
+        # Should NOT be wrapped in <pre> tags
+        self.assertNotIn("<pre>", xml)
+        # The link should be sanitized (target stripped, href kept)
+        self.assertIn('<a href="https://graphite.dev">View</a>', xml)
+
+    def test_fenced_code_block_with_html_stays_as_code(self):
+        """Fenced code blocks should remain as <pre> even if they contain HTML."""
+        md = '```html\n<div>example</div>\n```'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertIn("<pre>", xml)
+        self.assertIn("&lt;div&gt;", xml)
+
+    def test_indented_code_without_html_stays_as_code(self):
+        """Plain indented code (no HTML tags) should remain as <pre>."""
+        md = "    x = 1\n    y = 2\n"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertIn("<pre>", xml)
+        self.assertIn("x = 1", xml)
+
+    def test_bare_urls_in_block_html_are_autolinked(self):
+        """Bare URLs inside block-level HTML should become clickable links."""
+        html = "<details><summary>Links</summary>Visit https://example.com for info</details>"
+        xml = convert_github_markdown_to_asana_xml(html)
+        self.assertIn('<a href="https://example.com">', xml)
+
+    def test_markdown_link_with_javascript_url_is_escaped(self):
+        """Markdown [text](javascript:...) links should be escaped, not rendered."""
+        md = '[click](javascript:alert(1))'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertNotIn("javascript:", xml)
+        self.assertIn("click", xml)
+
+    def test_graphite_full_comment(self):
+        """Full Graphite stack comment — indented HTML + block HTML + comment."""
+        md = (
+            '        #389132 <a href="https://graphite.dev/pr/123" target="_blank">'
+            '<img src="https://graphite.dev/icon.png" alt="Graphite" width="10"/></a>'
+            '\n\n        next-master\n\n    \n'
+            '<h2></h2>Managed by <a href="https://graphite.dev"><b>Graphite</b></a>.\n'
+            '<!-- deps -->'
+        )
+        xml = convert_github_markdown_to_asana_xml(md)
+        # Indented section: HTML sanitized, not code-blocked
+        self.assertNotIn("<pre>", xml)
+        self.assertIn('<a href="https://graphite.dev/pr/123">', xml)
+        self.assertNotIn("target=", xml)
+        # Block HTML section: h2 stripped, bold/link preserved, comment removed
+        self.assertNotIn("<h2>", xml)
+        self.assertIn("<b>Graphite</b>", xml)
+        self.assertNotIn("<!-- deps -->", xml)
+        self.assertNotIn("deps", xml)
 
 
 if __name__ == "__main__":

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,6 +1,5 @@
 import unittest
 
-from html import escape
 from src.markdown_parser import (
     convert_github_markdown_to_asana_xml,
     sanitize_html_for_asana,

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,7 +1,11 @@
 import unittest
 
 from html import escape
-from src.markdown_parser import convert_github_markdown_to_asana_xml, sanitize_html_for_asana
+from src.markdown_parser import (
+    convert_github_markdown_to_asana_xml,
+    sanitize_html_for_asana,
+    _contains_html_tags,
+)
 
 
 class TestConvertGithubMarkdownToAsanaXml(unittest.TestCase):
@@ -427,6 +431,22 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertIn("<pre>", xml)
         self.assertIn("x = 1", xml)
+
+    def test_indented_cpp_templates_stay_as_code(self):
+        """C++ templates with angle brackets should NOT trigger HTML detection."""
+        md = "    vector<int> v;\n    std::map<string, int> m;\n"
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertIn("<pre>", xml)
+        self.assertIn("vector", xml)
+
+    def test_html_detection_ignores_non_html_tag_names(self):
+        """_contains_html_tags only matches known HTML tag names."""
+        self.assertFalse(_contains_html_tags("vector<int> v;"))
+        self.assertFalse(_contains_html_tags("dict['<key>']"))
+        self.assertFalse(_contains_html_tags("template<class T>"))
+        self.assertTrue(_contains_html_tags('<a href="x">link</a>'))
+        self.assertTrue(_contains_html_tags("<details>content</details>"))
+        self.assertTrue(_contains_html_tags('<img src="x.png"/>'))
 
     def test_bare_urls_in_block_html_are_autolinked(self):
         """Bare URLs inside block-level HTML should become clickable links."""

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -220,9 +220,19 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
             html = f"<h{level}>Heading</h{level}>"
             self.assertEqual(sanitize_html_for_asana(html), "Heading")
 
-    def test_strips_table_tags_preserves_text(self):
+    def test_strips_table_tags_preserves_text_with_separators(self):
         html = "<table><tr><th>Name</th><th>Status</th></tr><tr><td>foo</td><td>OK</td></tr></table>"
-        self.assertEqual(sanitize_html_for_asana(html), "NameStatusfooOK")
+        self.assertEqual(
+            sanitize_html_for_asana(html), "Name | Status\nfoo | OK\n"
+        )
+
+    def test_single_cell_row_has_no_leading_separator(self):
+        html = "<table><tr><td>only cell</td></tr></table>"
+        self.assertEqual(sanitize_html_for_asana(html), "only cell\n")
+
+    def test_three_column_table(self):
+        html = "<table><tr><td>A</td><td>B</td><td>C</td></tr></table>"
+        self.assertEqual(sanitize_html_for_asana(html), "A | B | C\n")
 
     def test_strips_p_tags(self):
         html = "<p>paragraph text</p>"


### PR DESCRIPTION
## Problem

SGTM syncs GitHub PR comments to Asana tasks. Bot comments from Graphite, Spacelift, Cursor Bugbot, and github-actions make heavy use of raw HTML — collapsible `<details>/<summary>` sections, tables, links with `target="_blank"`, `<img>` badges, HTML comments like `<!-- spacelift_id -->`, etc.

The markdown parser was blanket-escaping **all** raw HTML via `escape()`, so Asana rendered the literal tag text. For example, a Spacelift CI results comment would show up as:

```
<!-- spacelift_propose_runs_identifier -->Commit: b2c85ab6
<details><summary>(1 / 1 prod-like) Spacelift Stacks affected by this PR:
</summary><ul><li>buildinfra-corp: <a href='https://asana.app.spacelift.io/
stack/buildinfra-corp'>...</a></li></ul></details>
```

This is unreadable. Every Codez PR gets a Graphite comment with the same problem, so the issue is ubiquitous.

## Solution

Replace the `escape()` calls in `inline_html()` / `block_html()` with a new `_AsanaHTMLSanitizer` (Python stdlib `HTMLParser`) that intelligently processes HTML:

| Input | Behavior |
|---|---|
| Asana-supported tags (`<a>`, `<b>`, `<em>`, `<ul>`, `<li>`, `<code>`, etc.) | **Pass through** with sanitized attributes |
| Unsupported wrappers (`<details>`, `<summary>`, `<div>`, `<table>`, `<h1>`–`<h6>`, `<p>`, etc.) | **Strip tag, keep text content**, with newlines at block boundaries |
| `<img src="..." alt="...">` | **Convert to `<a>` link** |
| `<td>`/`<th>` cells | **Insert ` \| ` separators** between cells, `\n` at row boundaries |
| `<br>` | **Convert to newline** |
| `<!-- HTML comments -->` | **Strip entirely** |
| `javascript:` / `data:` URLs in `href` | **Blocked** (scheme allowlist: http/https/mailto) |
| Bare URLs in block HTML | **Auto-linked** (matches the markdown renderer's behavior) |
| All text content | **Escaped** (safe from injection) |

Additional fixes beyond the core sanitizer:
- **Indented HTML detection**: Graphite formats comments with leading spaces, which mistune treats as `<pre>` code blocks. `block_code()` now detects indented blocks that contain HTML tags and sanitizes them instead of wrapping in `<pre>`. Fenced code blocks and plain indented code are unaffected.
- **`link()` hardening**: The pre-existing `_is_valid_url()` (scheme + netloc check) accepted `javascript://x/...`. Replaced with `_is_safe_url()` (explicit scheme allowlist), closing a pre-existing bypass in markdown link rendering.

## After

The same Spacelift comment now renders as:

```
Commit: b2c85ab6 (merge commit from 3c71762b)
(1 / 1 prod-like) Spacelift Stacks affected by this PR:
• buildinfra-corp: [clickable link]

Spacelift Run Results
✅ All 1 runs completed successfully
View all 1 stack
buildinfra-corp | ✅ FINISHED | [clickable link]
```

And in Asana's rich-text view, the bullet lists, bold text, and links all render with proper formatting.

## Test plan
- [x] 297 existing tests pass (0 new failures; 7 pre-existing failures in `test_extract_attachments.py` are unrelated)
- [x] 42 new tests added covering: Asana-supported tag passthrough, unsupported tag stripping, block boundary whitespace, table cell separators, `<img>` conversion, `<br>`/`<hr>`, HTML comment removal, URL scheme validation, attribute deduplication, bare URL auto-linking, indented HTML detection, entity preservation, and real-world comment patterns from Spacelift, Graphite, Cursor Bugbot, and Graphite Automations
- [ ] Verify on a real SGTM task that bot comments render cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)