### PR TITLE
Flatten nested <a> tags to unblock Asana rendering of bot comments

### DIFF
--- a/src/asana/helpers.py
+++ b/src/asana/helpers.py
@@ -559,7 +559,10 @@ def asana_comment_from_github_review(review: Review) -> str:
         # even though nothing in github looks like a review
         # If that's the case, there is no meaningful review state ("commented" isn't helpful)
         # and the link to it will either not point anywhere, or be less useful than the individual links on each comment.
-        review_action = _wrap_in_tag("strong")("left inline comments:\n")
+        # Note: this stays as plain text — the outer header wraps the full
+        # phrase in <strong> already; pre-wrapping here would produce
+        # <strong>NAME <strong>left inline comments:</strong></strong>.
+        review_action = "left inline comments:\n"
     else:
         review_action = _wrap_in_tag("A", attrs={"href": review.url()})(
             _review_action_to_text_map.get(review.state(), "commented")

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -68,34 +68,6 @@ _BLOCK_LEVEL_TAGS = frozenset(
     }
 )
 
-# Known HTML tag names, used to distinguish indented bot HTML from genuine
-# code blocks.  A simple regex like `<[a-zA-Z]...>` would false-positive on
-# C++ templates (vector<int>), angle-bracket strings, etc.  Checking against
-# actual HTML tag names avoids those cases.
-_KNOWN_HTML_TAG_NAMES = frozenset(
-    {
-        "a", "abbr", "article", "aside", "b", "blockquote", "br", "button",
-        "caption", "code", "col", "colgroup", "dd", "del", "details", "div",
-        "dl", "dt", "em", "figcaption", "figure", "footer", "form",
-        "h1", "h2", "h3", "h4", "h5", "h6",
-        "header", "hr", "i", "iframe", "img", "input", "ins", "label", "li",
-        "main", "nav", "ol", "option", "p", "picture", "pre", "s", "section",
-        "select", "source", "span", "strong", "sub", "summary", "sup",
-        "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "tr",
-        "u", "ul", "video",
-    }
-)
-_TAG_NAME_RE = re.compile(r"<([a-zA-Z][a-zA-Z0-9]*)")
-
-
-def _contains_html_tags(text: str) -> bool:
-    """Return True if *text* contains what looks like a known HTML tag."""
-    for m in _TAG_NAME_RE.finditer(text):
-        if m.group(1).lower() in _KNOWN_HTML_TAG_NAMES:
-            return True
-    return False
-
-
 def _urlreplace(matchobj: Match[str]) -> str:
     """Replace a bare URL match with an <a> tag. Used by both the markdown
     renderer's text() method and the HTML sanitizer's handle_data()."""
@@ -248,12 +220,6 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
     def block_code(self, code, info=None):
         #  Strip the '\r\n' from the end of the code text that Github automatically adds
         code = code.rstrip("\r\n")
-        # Fenced code blocks (info is set, e.g. ```python) are always real code.
-        # Indented code blocks (info=None) that contain HTML tags are likely
-        # bot comments with cosmetic leading whitespace, not actual code —
-        # sanitize them instead of rendering as <pre>.
-        if info is None and _contains_html_tags(code):
-            return sanitize_html_for_asana(code)
         return "<pre>" + escape(code) + "</pre>"
 
     def text(self, text) -> str:

--- a/src/markdown_parser.py
+++ b/src/markdown_parser.py
@@ -94,12 +94,17 @@ class _AsanaHTMLSanitizer(HTMLParser):
     - Passes through <hr />
     - Removes HTML comments entirely
     - Validates URL schemes (only http/https/mailto allowed)
+    - Flattens nested <a> tags — keeping only the outermost — because
+      Asana's rich text parser rejects invalid nested anchors.  The
+      caller may seed anchor_depth so tracking carries across sanitizer
+      invocations (e.g. per-tag inline_html calls within one document).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, anchor_depth: int = 0) -> None:
         super().__init__(convert_charrefs=False)
         self._parts: list = []
         self._cell_count_in_row = 0  # tracks cell position within a <tr>
+        self.anchor_depth = anchor_depth  # nested <a> depth; public for cross-call carry
 
     def handle_starttag(self, tag: str, attrs: list) -> None:
         tag_lower = tag.lower()
@@ -113,6 +118,10 @@ class _AsanaHTMLSanitizer(HTMLParser):
             self._cell_count_in_row = 0
             return
         if tag_lower in _ASANA_SUPPORTED_TAGS:
+            if tag_lower == "a":
+                self.anchor_depth += 1
+                if self.anchor_depth > 1:
+                    return  # Suppress nested <a>; keep only the outermost
             allowed = _ASANA_ALLOWED_ATTRS.get(tag_lower, frozenset())
             safe_attrs = []
             seen_keys = set()
@@ -130,7 +139,12 @@ class _AsanaHTMLSanitizer(HTMLParser):
             attrs_dict = dict(attrs)
             src = attrs_dict.get("src", "")
             alt = attrs_dict.get("alt", "")
-            if src and _is_safe_url(src):
+            if self.anchor_depth > 0:
+                # Already inside an <a>; emit alt text only (no wrapping anchor)
+                # to avoid producing nested anchors.
+                if alt:
+                    self._parts.append(escape(alt, quote=False))
+            elif src and _is_safe_url(src):
                 self._parts.append(
                     f'<a href="{escape(src)}">{escape(alt or src)}</a>'
                 )
@@ -150,6 +164,12 @@ class _AsanaHTMLSanitizer(HTMLParser):
         if tag_lower in _TABLE_CELL_TAGS:
             return  # closing </td>/</th> needs no output
         if tag_lower in _ASANA_SUPPORTED_TAGS:
+            if tag_lower == "a" and self.anchor_depth > 0:
+                self.anchor_depth -= 1
+                if self.anchor_depth > 0:
+                    return  # Inner </a>; the outer <a> is still open
+            # If anchor_depth is already 0, this </a> may pair with an <a>
+            # emitted by a previous inline_html() call, so emit it anyway.
             self._parts.append(f"</{tag_lower}>")
         elif tag_lower in _BLOCK_LEVEL_TAGS:
             # Avoid consecutive newlines from deeply nested block elements
@@ -160,8 +180,11 @@ class _AsanaHTMLSanitizer(HTMLParser):
     def handle_data(self, data: str) -> None:
         text = escape(data, quote=False)
         # Auto-link bare URLs, matching the behavior of the markdown
-        # renderer's text() method.
-        text = re.sub(URL_REGEX, _urlreplace, text)
+        # renderer's text() method — but skip when we're already inside an
+        # <a> element, otherwise we'd wrap a URL inside another anchor and
+        # produce invalid nested <a><a>...</a></a>.
+        if self.anchor_depth == 0:
+            text = re.sub(URL_REGEX, _urlreplace, text)
         self._parts.append(text)
 
     def handle_entityref(self, name: str) -> None:
@@ -190,6 +213,16 @@ def sanitize_html_for_asana(html: str) -> str:
 
 
 class GithubToAsanaRenderer(mistune.HTMLRenderer):
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        # Mistune's inline parser splits inline HTML into one inline_html()
+        # call per tag (e.g. <a>, <img>, </a> are three separate calls).  To
+        # flatten nested anchors that span those calls (Graphite stack
+        # comments and Cursor Bugbot "Fix in Cursor" buttons both produce
+        # <a href="..."><img src="..."/></a> in list items / paragraphs),
+        # we carry anchor depth across sanitize invocations on this renderer.
+        self._inline_anchor_depth = 0
+
     def paragraph(self, text) -> str:
         return text + "\n"
 
@@ -206,9 +239,17 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
         return "<hr />"
 
     def inline_html(self, html) -> str:
-        return sanitize_html_for_asana(html)
+        # Use the sanitizer class directly (not the simple helper) so we can
+        # thread anchor_depth across successive inline_html() calls.
+        sanitizer = _AsanaHTMLSanitizer(anchor_depth=self._inline_anchor_depth)
+        sanitizer.feed(html)
+        self._inline_anchor_depth = sanitizer.anchor_depth
+        return sanitizer.get_result()
 
     def block_html(self, html) -> str:
+        # Block HTML is handled as a complete unit — a fresh sanitizer is
+        # fine since everything between the opening and closing tags of the
+        # block is passed as one string.
         return sanitize_html_for_asana(html)
 
     def linebreak(self) -> str:
@@ -224,7 +265,12 @@ class GithubToAsanaRenderer(mistune.HTMLRenderer):
 
     def text(self, text) -> str:
         text = escape(text, quote=False)
-        return re.sub(URL_REGEX, _urlreplace, text)
+        # Skip bare-URL auto-linking when we're inside an <a> emitted by a
+        # previous inline_html() call — otherwise the URL would be wrapped
+        # in a second <a>, producing invalid nested anchors.
+        if self._inline_anchor_depth == 0:
+            text = re.sub(URL_REGEX, _urlreplace, text)
+        return text
 
     def link(self, link, text=None, title=None):
         # the parser may pass in `title`, but Asana's API does not allow the

--- a/test/asana/helpers/test_asana_comment_from_github_review.py
+++ b/test/asana/helpers/test_asana_comment_from_github_review.py
@@ -242,6 +242,28 @@ class TestAsanaCommentFromGitHubReview(MockDynamoDbTestCase):
         )
         self.assertContainsStrings(asana_review_comment, [f'<A href="{url}">'])
 
+    def test_just_comments_review_does_not_double_wrap_strong(self):
+        """When is_just_comments() is True (e.g. Cursor Bugbot inline reviews),
+        the 'left inline comments:' phrase must not be pre-wrapped in <strong>
+        because the outer header already wraps the whole phrase."""
+        # A review with state=COMMENTED and no body → is_just_comments() is True
+        github_comment = build(builder.comment().body("an inline comment"))
+        github_review = build(
+            builder.review()
+            .state(ReviewState.COMMENTED)
+            .body("")  # empty body triggers is_just_comments
+            .comment(github_comment)
+        )
+        asana_review_comment = asana_helpers.asana_comment_from_github_review(
+            github_review
+        )
+        # The header section should contain exactly ONE pair of <strong> tags
+        # around "NAME left inline comments:" — not nested <strong><strong>.
+        self.assertNotIn("<strong><strong>", asana_review_comment)
+        self.assertNotIn("</strong></strong>", asana_review_comment)
+        # Sanity: the phrase is still emitted
+        self.assertContainsStrings(asana_review_comment, ["left inline comments:"])
+
 
 if __name__ == "__main__":
     from unittest import main as run_tests

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 from src.markdown_parser import (
@@ -433,6 +434,101 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertNotIn("javascript:", xml)
         self.assertIn("click", xml)
+
+
+class TestAnchorFlatteningAcrossInlineCalls(unittest.TestCase):
+    """Nested <a> tags must be flattened regardless of whether the tags are
+    tokenized by mistune as one block or split into per-tag inline_html calls."""
+
+    def test_graphite_stack_list_item_flattens_nested_anchors(self):
+        """Real Graphite stack source: list item with <a href><img></a>.
+
+        Mistune tokenizes this as per-tag inline_html calls (one call each
+        for <a>, <img>, </a>).  Without renderer-level anchor tracking the
+        <img> would convert to a second <a> nested inside the outer one.
+        """
+        # Exact source pulled from GitHub (issue comment 4270446033)
+        md = (
+            '* **#389656** '
+            '<a href="https://app.graphite.com/github/pr/Asana/codez/389656" target="_blank">'
+            '<img src="https://static.graphite.dev/graphite-32x32-black.png" alt="Graphite" width="10px" height="10px"/>'
+            '</a>'
+            ' 👈 '
+            '<a href="https://app.graphite.com/github/pr/Asana/codez/389656?utm_source=stack-comment-view-in-graphite" target="_blank">(View in Graphite)</a>\n'
+            '* `next-master`\n'
+        )
+        xml = convert_github_markdown_to_asana_xml(md)
+
+        # Assert: no nested <a> — the critical property
+        nested = re.findall(r'<a[^>]*>(?:(?!</a>).)*<a\b', xml, flags=re.DOTALL)
+        self.assertEqual(
+            nested, [], f"Unexpected nested anchors in output:\n{xml}"
+        )
+        # Outer anchor should still be present with its Graphite label text
+        self.assertIn(
+            '<a href="https://app.graphite.com/github/pr/Asana/codez/389656">Graphite</a>',
+            xml,
+        )
+        # Second (text) link unchanged
+        self.assertIn("(View in Graphite)</a>", xml)
+
+    def test_cursor_bugbot_fix_button_in_paragraph_flattens_nested_anchors(self):
+        """Real Cursor Bugbot pattern: <a href><picture><source><img></picture></a>
+        as a paragraph of per-tag inline_html calls."""
+        md = (
+            '<!-- BUGBOT_FIX_ALL -->\n'
+            '<a href="https://cursor.com/open?data=JWT" target="_blank" rel="noopener noreferrer">'
+            '<picture>'
+            '<source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/fix-dark.png">'
+            '<source media="(prefers-color-scheme: light)" srcset="https://cursor.com/fix-light.png">'
+            '<img alt="Fix All in Cursor" width="115" height="28" src="https://cursor.com/fix-dark.png">'
+            '</picture></a>\n'
+            '<!-- /BUGBOT_FIX_ALL -->\n'
+        )
+        xml = convert_github_markdown_to_asana_xml(md)
+        nested = re.findall(r'<a[^>]*>(?:(?!</a>).)*<a\b', xml, flags=re.DOTALL)
+        self.assertEqual(
+            nested, [], f"Unexpected nested anchors in output:\n{xml}"
+        )
+        # Outer Cursor link preserved with alt text as the label
+        self.assertIn('<a href="https://cursor.com/open?data=JWT">', xml)
+        self.assertIn("Fix All in Cursor", xml)
+
+    def test_anchor_depth_resets_between_top_level_renders(self):
+        """Two separate convert_github_markdown_to_asana_xml() calls must not
+        share anchor depth — each should start fresh."""
+        # First call leaves depth at 0 (balanced)
+        xml1 = convert_github_markdown_to_asana_xml('<a href="https://a.com">one</a>')
+        # Second call should render a standalone link normally
+        xml2 = convert_github_markdown_to_asana_xml('<a href="https://b.com">two</a>')
+        self.assertIn('<a href="https://a.com">one</a>', xml1)
+        self.assertIn('<a href="https://b.com">two</a>', xml2)
+
+    def test_bare_url_inside_anchor_is_not_auto_linked(self):
+        """A bare URL as the text content of an <a> must NOT be re-wrapped
+        in another <a> by the URL auto-linker — that produces nested anchors.
+        Real-world trigger: Spacelift's <a href='URL'>URL</a> inside <details>
+        and Graphite-style inline tags with a URL between them."""
+        # Case 1: url inside inline <a> (mistune's text() path)
+        md = '<a href="https://example.com">visit https://example.com/path</a>'
+        xml = convert_github_markdown_to_asana_xml(md)
+        self.assertEqual(
+            0, len(re.findall(r'<a[^>]*>(?:(?!</a>).)*<a\b', xml, flags=re.DOTALL)),
+            f"nested anchors in: {xml}",
+        )
+
+        # Case 2: url inside <a> in block HTML (sanitizer's handle_data path)
+        md2 = "<div><a href='https://example.com'>https://example.com</a></div>"
+        xml2 = convert_github_markdown_to_asana_xml(md2)
+        self.assertEqual(
+            0, len(re.findall(r'<a[^>]*>(?:(?!</a>).)*<a\b', xml2, flags=re.DOTALL)),
+            f"nested anchors in: {xml2}",
+        )
+
+        # Sanity: bare URL outside any anchor still auto-links
+        md3 = "See https://example.com for info"
+        xml3 = convert_github_markdown_to_asana_xml(md3)
+        self.assertIn('<a href="https://example.com">https://example.com</a>', xml3)
 
 
 if __name__ == "__main__":

--- a/test/test_markdown_parser.py
+++ b/test/test_markdown_parser.py
@@ -3,7 +3,6 @@ import unittest
 from src.markdown_parser import (
     convert_github_markdown_to_asana_xml,
     sanitize_html_for_asana,
-    _contains_html_tags,
 )
 
 
@@ -408,44 +407,19 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         self.assertIn('<a href="https://example.com">here</a>', xml)
         self.assertNotIn("target=", xml)
 
-    def test_indented_html_is_sanitized_not_code_blocked(self):
-        """Indented HTML (common in bot comments) is sanitized, not treated as <pre>."""
-        md = '        #123 <a href="https://graphite.dev" target="_blank">View</a>\n\n        next-master\n'
-        xml = convert_github_markdown_to_asana_xml(md)
-        # Should NOT be wrapped in <pre> tags
-        self.assertNotIn("<pre>", xml)
-        # The link should be sanitized (target stripped, href kept)
-        self.assertIn('<a href="https://graphite.dev">View</a>', xml)
-
-    def test_fenced_code_block_with_html_stays_as_code(self):
-        """Fenced code blocks should remain as <pre> even if they contain HTML."""
+    def test_fenced_code_block_preserves_html_as_code(self):
+        """Fenced code blocks remain as <pre> with HTML escaped — unchanged mistune default."""
         md = '```html\n<div>example</div>\n```'
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertIn("<pre>", xml)
         self.assertIn("&lt;div&gt;", xml)
 
-    def test_indented_code_without_html_stays_as_code(self):
-        """Plain indented code (no HTML tags) should remain as <pre>."""
+    def test_indented_code_stays_as_code(self):
+        """Plain indented code remains as <pre> — unchanged mistune default."""
         md = "    x = 1\n    y = 2\n"
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertIn("<pre>", xml)
         self.assertIn("x = 1", xml)
-
-    def test_indented_cpp_templates_stay_as_code(self):
-        """C++ templates with angle brackets should NOT trigger HTML detection."""
-        md = "    vector<int> v;\n    std::map<string, int> m;\n"
-        xml = convert_github_markdown_to_asana_xml(md)
-        self.assertIn("<pre>", xml)
-        self.assertIn("vector", xml)
-
-    def test_html_detection_ignores_non_html_tag_names(self):
-        """_contains_html_tags only matches known HTML tag names."""
-        self.assertFalse(_contains_html_tags("vector<int> v;"))
-        self.assertFalse(_contains_html_tags("dict['<key>']"))
-        self.assertFalse(_contains_html_tags("template<class T>"))
-        self.assertTrue(_contains_html_tags('<a href="x">link</a>'))
-        self.assertTrue(_contains_html_tags("<details>content</details>"))
-        self.assertTrue(_contains_html_tags('<img src="x.png"/>'))
 
     def test_bare_urls_in_block_html_are_autolinked(self):
         """Bare URLs inside block-level HTML should become clickable links."""
@@ -459,26 +433,6 @@ class TestSanitizeHtmlForAsana(unittest.TestCase):
         xml = convert_github_markdown_to_asana_xml(md)
         self.assertNotIn("javascript:", xml)
         self.assertIn("click", xml)
-
-    def test_graphite_full_comment(self):
-        """Full Graphite stack comment — indented HTML + block HTML + comment."""
-        md = (
-            '        #389132 <a href="https://graphite.dev/pr/123" target="_blank">'
-            '<img src="https://graphite.dev/icon.png" alt="Graphite" width="10"/></a>'
-            '\n\n        next-master\n\n    \n'
-            '<h2></h2>Managed by <a href="https://graphite.dev"><b>Graphite</b></a>.\n'
-            '<!-- deps -->'
-        )
-        xml = convert_github_markdown_to_asana_xml(md)
-        # Indented section: HTML sanitized, not code-blocked
-        self.assertNotIn("<pre>", xml)
-        self.assertIn('<a href="https://graphite.dev/pr/123">', xml)
-        self.assertNotIn("target=", xml)
-        # Block HTML section: h2 stripped, bold/link preserved, comment removed
-        self.assertNotIn("<h2>", xml)
-        self.assertIn("<b>Graphite</b>", xml)
-        self.assertNotIn("<!-- deps -->", xml)
-        self.assertNotIn("deps", xml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #223, driven by real rendering failures observed in Asana after #223 deployed. Three focused HTML-correctness fixes.

## The real problem

After #223 landed in prod, Graphite stack comments and Cursor Bugbot reviews still rendered in Asana as plain text with raw `<a>`, `<ul>`, `<li>`, etc. visible:

> `<body><strong>GitHub user 'cursor' <strong>left inline comments:</strong></strong>...<a href="..."><a href="...">Fix in Cursor</a></a>...`

Root cause: tracing [Asana's server-side rich text parser](https://github.com/Asana/asana/blob/master/asana2/asana/web/rich_text/helpers/luna_text/v1/html_luna_text_v1_converter.ts#L128-L132) shows it **panics on nested `<a>` tags** and falls back to plain-text-with-auto-linking for the entire story. The sanitizer in #223 was producing nested anchors in a specific, very common case.

## The three fixes

### 1. Revert dead `block_code` HTML detection
PR #223 added heuristic detection of HTML inside indented code blocks (meant to catch bots that use 4-space indentation cosmetically). Pulling real bot comment sources from GitHub and tracing through mistune confirms **no bot actually triggers that path**:
- Graphite stack: `* ` markdown list → `<ul><li>`
- Cursor Bugbot / Spacelift / github-actions: HTML at column 0 → `block_html`
- Precommit warnings: `### PRECOMMIT WARNINGS` heading at column 0

The detection also has a downside: a reviewer who *intentionally* shows HTML as code via 4-space indentation would get their markup stripped and sanitized. Remove the detection + supporting constants (`_contains_html_tags`, `_KNOWN_HTML_TAG_NAMES`, `_TAG_NAME_RE`).

### 2. Flatten nested `<a>` tags across `inline_html` calls
This is the fix for the actual rendering bug.

Mistune's inline parser tokenizes raw HTML as **one call per tag** — `<a>`, `<img>`, `</a>` inside a paragraph or list item are three separate `inline_html()` invocations. Before this change, each invocation got a fresh sanitizer with `anchor_depth=0`, so when `<img>` arrived it didn't know it was already inside an `<a>` and converted to a second `<a>`, producing `<a href="..."><a href="...">...</a></a>`.

Fix: give `_AsanaHTMLSanitizer` a public `anchor_depth` attribute. `GithubToAsanaRenderer` tracks `_inline_anchor_depth` on the renderer instance and threads it across successive `inline_html()` calls within one document render. Also skip bare-URL auto-linking (in both the sanitizer's `handle_data` and the renderer's `text()`) while `anchor_depth > 0`, to avoid a second nesting path when a bare URL appears as the text of an `<a>`.

### 3. Remove double `<strong>` wrap in `asana_comment_from_github_review`
When `review.is_just_comments()` is True (e.g. Cursor Bugbot inline reviews), `review_action` was pre-wrapped in `<strong>` and then the outer header wrapped the whole phrase in `<strong>` again, producing `<strong>NAME <strong>left inline comments:</strong></strong>`. Nested `<strong>` is tolerated by Asana's parser (unlike nested `<a>`) so this isn't breaking rendering, but it's redundant and inconsistent with the non-just-comments branch. Fixed by letting `review_action` be plain text in that branch.

## Validation

Two datasets pulled live from GitHub and run through the branch sanitizer:

**1. Bot-authored comments on 200 recent Asana/codez PRs** — 385 comments across 7 distinct bots:

| Bot | Count | Result |
|---|---:|---|
| `cursor[bot]` | 224 | ✅ clean |
| `github-actions[bot]` (Spacelift, Cell App Report, etc.) | 73 | ✅ clean |
| `pr-velocity-bot-reapprover[bot]` | 33 | ✅ clean |
| `pr-velocity-bot[bot]` | 20 | ✅ clean |
| `graphite-app[bot]` (Automations) | 18 | ✅ clean |
| `semgrep-code-asana[bot]` | 11 | ✅ clean |
| `asana-sgtm[bot]` | 6 | ✅ clean |

**2. Graphite stack comments** — posted as the human PR author via the Graphite app (not filtered as "Bot" by the GitHub API). 15 comments sampled across 14 different human authors → ✅ 15/15 clean.

**Combined: 400+ comments, zero nested `<a>` tags, zero escaped HTML tags, zero unstripped HTML comments in the sanitized output.**

Visually spot-checked rendered output for every distinct (bot, comment-kind) combination in the corpus: the previously-broken patterns (Graphite stack list-item with `<a><img/></a>`, Cursor Bugbot Fix button with `<a><picture><img></picture></a>`, Spacelift `<a href='URL'>URL</a>` inside `<details>`) all produce well-formed html_text with exactly balanced anchors.

## Test plan
- [x] 300 existing tests pass
- [x] New tests added:
  - Anchor flattening across `inline_html` calls (Graphite stack + Cursor Bugbot Fix button patterns)
  - Anchor-depth resets between top-level render calls
  - Bare URL inside an existing `<a>` doesn't auto-link (both mistune `text()` and sanitizer `handle_data` paths)
  - Just-comments review header uses a single `<strong>` wrap
- [ ] Verify on a real SGTM task after deployment that Graphite + Cursor Bugbot comments render with clickable links and formatting, no raw tags visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)